### PR TITLE
Replace calendar with CalendarDatePicker, update accent to #F7A5A5, and add placeholder screens/routes

### DIFF
--- a/lib/app.dart
+++ b/lib/app.dart
@@ -13,7 +13,9 @@ class MyApp extends StatelessWidget {
       initialRoute: Routes.main,
       onGenerateRoute: AppRouter.generateRoute,
       theme: ThemeData(
-        colorScheme: ColorScheme.fromSeed(seedColor: Colors.deepPurple),
+        colorScheme: ColorScheme.fromSeed(
+          seedColor: const Color(0xFFF7A5A5),
+        ),
       ),
     );
   }

--- a/lib/routes/app_router.dart
+++ b/lib/routes/app_router.dart
@@ -1,22 +1,49 @@
 import 'package:flutter/material.dart';
 import 'routes.dart';
+import '../screen/auth/login_screen.dart';
+import '../screen/auth/sighup_screen.dart';
+import '../screen/cash/cash_detail__screen.dart';
+import '../screen/day/day_detail__screen.dart';
 import '../screen/main_screen.dart';
-
-// TODO: 화면들 만들면 여기 import 추가
-// import '../screens/start/start_screen.dart';
-// import '../screens/auth/login_screen.dart';
+import '../screen/my/mypage_screen.dart';
+import '../screen/start/start_screen.dart';
 
 class AppRouter {
   static Route<dynamic> generateRoute(RouteSettings settings) {
     switch (settings.name) {
       case Routes.start:
         return MaterialPageRoute(
-          builder: (_) => const _PlaceholderScreen(title: 'START'),
+          builder: (_) => const StartScreen(),
+          settings: settings,
+        );
+      case Routes.login:
+        return MaterialPageRoute(
+          builder: (_) => const LoginScreen(),
+          settings: settings,
+        );
+      case Routes.signup:
+        return MaterialPageRoute(
+          builder: (_) => const SignupScreen(),
           settings: settings,
         );
       case Routes.main:
         return MaterialPageRoute(
           builder: (_) => const MainScreen(),
+          settings: settings,
+        );
+      case Routes.dayDetail:
+        return MaterialPageRoute(
+          builder: (_) => const DayDetailScreen(),
+          settings: settings,
+        );
+      case Routes.cashDetail:
+        return MaterialPageRoute(
+          builder: (_) => const CashDetailScreen(),
+          settings: settings,
+        );
+      case Routes.mypage:
+        return MaterialPageRoute(
+          builder: (_) => const MyPageScreen(),
           settings: settings,
         );
 

--- a/lib/routes/routes.dart
+++ b/lib/routes/routes.dart
@@ -1,6 +1,9 @@
 class Routes {
   static const start = '/';
   static const login = '/login';
+  static const signup = '/signup';
   static const main = '/main';
   static const dayDetail = '/day-detail';
+  static const cashDetail = '/cash-detail';
+  static const mypage = '/mypage';
 }

--- a/lib/screen/auth/login_screen.dart
+++ b/lib/screen/auth/login_screen.dart
@@ -1,0 +1,16 @@
+import 'package:flutter/material.dart';
+import '../../widgets/template/base_scaffold.dart';
+
+class LoginScreen extends StatelessWidget {
+  const LoginScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return BaseScaffold(
+      title: 'Login',
+      body: const Center(
+        child: Text('로그인 화면'),
+      ),
+    );
+  }
+}

--- a/lib/screen/auth/sighup_screen.dart
+++ b/lib/screen/auth/sighup_screen.dart
@@ -1,0 +1,16 @@
+import 'package:flutter/material.dart';
+import '../../widgets/template/base_scaffold.dart';
+
+class SignupScreen extends StatelessWidget {
+  const SignupScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return BaseScaffold(
+      title: 'Signup',
+      body: const Center(
+        child: Text('회원가입 화면'),
+      ),
+    );
+  }
+}

--- a/lib/screen/cash/cash_detail__screen.dart
+++ b/lib/screen/cash/cash_detail__screen.dart
@@ -1,0 +1,16 @@
+import 'package:flutter/material.dart';
+import '../../widgets/template/base_scaffold.dart';
+
+class CashDetailScreen extends StatelessWidget {
+  const CashDetailScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return BaseScaffold(
+      title: 'Cash Detail',
+      body: const Center(
+        child: Text('가계부 페이지'),
+      ),
+    );
+  }
+}

--- a/lib/screen/day/day_detail__screen.dart
+++ b/lib/screen/day/day_detail__screen.dart
@@ -1,0 +1,16 @@
+import 'package:flutter/material.dart';
+import '../../widgets/template/base_scaffold.dart';
+
+class DayDetailScreen extends StatelessWidget {
+  const DayDetailScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return BaseScaffold(
+      title: 'Day Detail',
+      body: const Center(
+        child: Text('일정 상세 페이지'),
+      ),
+    );
+  }
+}

--- a/lib/screen/main_screen.dart
+++ b/lib/screen/main_screen.dart
@@ -1,16 +1,25 @@
 import 'package:flutter/material.dart';
+import '../routes/routes.dart';
 
-class MainScreen extends StatelessWidget {
+class MainScreen extends StatefulWidget {
   const MainScreen({super.key});
 
-  static const _userName = '세계';
-  static const _selectedDate = '9월 9일';
+  @override
+  State<MainScreen> createState() => _MainScreenState();
+}
 
-  static final List<_ScheduleItem> _scheduleItems = [
+class _MainScreenState extends State<MainScreen> {
+  static const _userName = '세계';
+  static const _primaryPink = Color(0xFFF7A5A5);
+  static const _initialDate = DateTime(2025, 9, 9);
+
+  DateTime _selectedDate = _initialDate;
+
+  final List<_ScheduleItem> _scheduleItems = [
     _ScheduleItem(
       label: '아침 운동',
       timeRange: '07:00 - 09:30',
-      color: const Color(0xFFF28B82),
+      color: _primaryPink,
     ),
     _ScheduleItem(
       label: '친구 약속',
@@ -19,11 +28,15 @@ class MainScreen extends StatelessWidget {
     ),
   ];
 
-  static final List<_AccountRecord> _records = [
+  final List<_AccountRecord> _records = [
     _AccountRecord(title: '월급', category: '수입', amount: 3200000),
     _AccountRecord(title: '점심', category: '지출', amount: -12000),
     _AccountRecord(title: '교통', category: '지출', amount: -3500),
   ];
+
+  String _formatDate(DateTime date) {
+    return '${date.month}월 ${date.day}일';
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -59,25 +72,44 @@ class MainScreen extends StatelessWidget {
                 child: Column(
                   crossAxisAlignment: CrossAxisAlignment.start,
                   children: [
-                    _CalendarHeader(),
-                    const SizedBox(height: 12),
-                    _CalendarGrid(),
+                    CalendarDatePicker(
+                      initialDate: _initialDate,
+                      firstDate: DateTime(2020),
+                      lastDate: DateTime(2030),
+                      currentDate: _selectedDate,
+                      onDateChanged: (date) {
+                        setState(() {
+                          _selectedDate = date;
+                        });
+                      },
+                    ),
                     const SizedBox(height: 16),
                     Row(
                       mainAxisAlignment: MainAxisAlignment.spaceBetween,
                       children: [
                         Text(
-                          _selectedDate,
+                          _formatDate(_selectedDate),
                           style: const TextStyle(
                             fontSize: 14,
                             fontWeight: FontWeight.w600,
                           ),
                         ),
-                        const Icon(Icons.notifications_none, size: 18),
+                        Row(
+                          children: [
+                            IconButton(
+                              icon: const Icon(Icons.chevron_right, size: 18),
+                              onPressed: () {
+                                Navigator.of(context)
+                                    .pushNamed(Routes.dayDetail);
+                              },
+                            ),
+                            const Icon(Icons.notifications_none, size: 18),
+                          ],
+                        ),
                       ],
                     ),
                     const SizedBox(height: 8),
-                    _CategoryTabs(),
+                    _CategoryTabs(primaryPink: _primaryPink),
                     const SizedBox(height: 10),
                     Expanded(
                       child: ListView(
@@ -105,172 +137,28 @@ class MainScreen extends StatelessWidget {
               ),
             ),
             const SizedBox(height: 16),
-            const _BottomNavBar(),
+            _BottomNavBar(primaryPink: _primaryPink),
           ],
         ),
       ),
-    );
-  }
-}
-
-class _CalendarHeader extends StatelessWidget {
-  @override
-  Widget build(BuildContext context) {
-    return Row(
-      mainAxisAlignment: MainAxisAlignment.spaceBetween,
-      children: [
-        const Icon(Icons.chevron_left, size: 20),
-        Row(
-          children: [
-            _DropdownChip(label: 'Sep'),
-            const SizedBox(width: 8),
-            _DropdownChip(label: '2025'),
-          ],
-        ),
-        const Icon(Icons.chevron_right, size: 20),
-      ],
-    );
-  }
-}
-
-class _DropdownChip extends StatelessWidget {
-  final String label;
-  const _DropdownChip({required this.label});
-
-  @override
-  Widget build(BuildContext context) {
-    return Container(
-      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
-      decoration: BoxDecoration(
-        borderRadius: BorderRadius.circular(16),
-        border: Border.all(color: const Color(0xFFE0E0E0)),
-      ),
-      child: Row(
-        children: [
-          Text(
-            label,
-            style: const TextStyle(fontSize: 12, fontWeight: FontWeight.w500),
-          ),
-          const Icon(Icons.expand_more, size: 14),
-        ],
-      ),
-    );
-  }
-}
-
-class _CalendarGrid extends StatelessWidget {
-  @override
-  Widget build(BuildContext context) {
-    const weekdays = ['Su', 'Mo', 'Tu', 'We', 'Th', 'Fr', 'Sa'];
-    const days = [
-      '',
-      '1',
-      '2',
-      '3',
-      '4',
-      '5',
-      '6',
-      '7',
-      '8',
-      '9',
-      '10',
-      '11',
-      '12',
-      '13',
-      '14',
-      '15',
-      '16',
-      '17',
-      '18',
-      '19',
-      '20',
-      '21',
-      '22',
-      '23',
-      '24',
-      '25',
-      '26',
-      '27',
-      '28',
-      '29',
-      '30',
-      '1',
-      '2',
-      '3',
-      '4',
-    ];
-
-    return Column(
-      children: [
-        Row(
-          mainAxisAlignment: MainAxisAlignment.spaceBetween,
-          children: weekdays
-              .map(
-                (day) => Expanded(
-                  child: Center(
-                    child: Text(
-                      day,
-                      style: const TextStyle(
-                        fontSize: 11,
-                        color: Colors.black54,
-                      ),
-                    ),
-                  ),
-                ),
-              )
-              .toList(),
-        ),
-        const SizedBox(height: 8),
-        Wrap(
-          spacing: 0,
-          runSpacing: 6,
-          children: days.asMap().entries.map((entry) {
-            final index = entry.key;
-            final day = entry.value;
-            final isSelected = day == '9';
-            final isMuted = day.isEmpty || index >= 30;
-            return SizedBox(
-              width: 36,
-              child: Center(
-                child: Container(
-                  width: 28,
-                  height: 28,
-                  decoration: BoxDecoration(
-                    color: isSelected ? const Color(0xFFF28B82) : null,
-                    shape: BoxShape.circle,
-                  ),
-                  alignment: Alignment.center,
-                  child: Text(
-                    day,
-                    style: TextStyle(
-                      fontSize: 12,
-                      color: isMuted
-                          ? Colors.black26
-                          : isSelected
-                              ? Colors.white
-                              : Colors.black87,
-                    ),
-                  ),
-                ),
-              ),
-            );
-          }).toList(),
-        ),
-      ],
     );
   }
 }
 
 class _CategoryTabs extends StatelessWidget {
+  final Color primaryPink;
+
+  const _CategoryTabs({required this.primaryPink});
+
   @override
   Widget build(BuildContext context) {
     return Row(
       children: [
-        _TabChip(label: '일정', isActive: true),
+        _TabChip(label: '일정', isActive: true, activeColor: primaryPink),
         const SizedBox(width: 8),
-        _TabChip(label: '수입', isActive: false),
+        _TabChip(label: '수입', isActive: false, activeColor: primaryPink),
         const SizedBox(width: 8),
-        _TabChip(label: '소비', isActive: false),
+        _TabChip(label: '소비', isActive: false, activeColor: primaryPink),
       ],
     );
   }
@@ -279,15 +167,20 @@ class _CategoryTabs extends StatelessWidget {
 class _TabChip extends StatelessWidget {
   final String label;
   final bool isActive;
+  final Color activeColor;
 
-  const _TabChip({required this.label, required this.isActive});
+  const _TabChip({
+    required this.label,
+    required this.isActive,
+    required this.activeColor,
+  });
 
   @override
   Widget build(BuildContext context) {
     return Container(
       padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
       decoration: BoxDecoration(
-        color: isActive ? const Color(0xFFF28B82) : const Color(0xFFF2F2F2),
+        color: isActive ? activeColor : const Color(0xFFF2F2F2),
         borderRadius: BorderRadius.circular(14),
       ),
       child: Text(
@@ -393,7 +286,9 @@ class _AccountRecordTile extends StatelessWidget {
 }
 
 class _BottomNavBar extends StatelessWidget {
-  const _BottomNavBar();
+  final Color primaryPink;
+
+  const _BottomNavBar({required this.primaryPink});
 
   @override
   Widget build(BuildContext context) {
@@ -401,14 +296,26 @@ class _BottomNavBar extends StatelessWidget {
       height: 56,
       margin: const EdgeInsets.symmetric(horizontal: 24),
       decoration: BoxDecoration(
-        color: const Color(0xFFF28B82),
+        color: primaryPink,
         borderRadius: BorderRadius.circular(20),
       ),
       child: Row(
-        children: const [
-          _BottomNavItem(label: 'CASH', isActive: false),
-          _BottomNavItem(label: 'HOME', isActive: true),
-          _BottomNavItem(label: 'MYPAGE', isActive: false),
+        children: [
+          _BottomNavItem(
+            label: 'CASH',
+            isActive: false,
+            onTap: () => Navigator.of(context).pushNamed(Routes.cashDetail),
+          ),
+          _BottomNavItem(
+            label: 'HOME',
+            isActive: true,
+            onTap: () => Navigator.of(context).pushNamed(Routes.main),
+          ),
+          _BottomNavItem(
+            label: 'MYPAGE',
+            isActive: false,
+            onTap: () => Navigator.of(context).pushNamed(Routes.mypage),
+          ),
         ],
       ),
     );
@@ -418,25 +325,34 @@ class _BottomNavBar extends StatelessWidget {
 class _BottomNavItem extends StatelessWidget {
   final String label;
   final bool isActive;
+  final VoidCallback onTap;
 
-  const _BottomNavItem({required this.label, required this.isActive});
+  const _BottomNavItem({
+    required this.label,
+    required this.isActive,
+    required this.onTap,
+  });
 
   @override
   Widget build(BuildContext context) {
     return Expanded(
-      child: Container(
-        alignment: Alignment.center,
-        decoration: BoxDecoration(
-          color: isActive ? const Color(0xFFEF7D75) : Colors.transparent,
-          borderRadius: BorderRadius.circular(14),
-        ),
-        margin: const EdgeInsets.symmetric(horizontal: 4, vertical: 8),
-        child: Text(
-          label,
-          style: const TextStyle(
-            fontSize: 12,
-            fontWeight: FontWeight.w600,
-            color: Colors.white,
+      child: InkWell(
+        borderRadius: BorderRadius.circular(14),
+        onTap: onTap,
+        child: Container(
+          alignment: Alignment.center,
+          decoration: BoxDecoration(
+            color: isActive ? const Color(0xFFF7A5A5) : Colors.transparent,
+            borderRadius: BorderRadius.circular(14),
+          ),
+          margin: const EdgeInsets.symmetric(horizontal: 4, vertical: 8),
+          child: Text(
+            label,
+            style: const TextStyle(
+              fontSize: 12,
+              fontWeight: FontWeight.w600,
+              color: Colors.white,
+            ),
           ),
         ),
       ),

--- a/lib/screen/my/mypage_screen.dart
+++ b/lib/screen/my/mypage_screen.dart
@@ -1,0 +1,16 @@
+import 'package:flutter/material.dart';
+import '../../widgets/template/base_scaffold.dart';
+
+class MyPageScreen extends StatelessWidget {
+  const MyPageScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return BaseScaffold(
+      title: 'My Page',
+      body: const Center(
+        child: Text('마이페이지'),
+      ),
+    );
+  }
+}

--- a/lib/screen/start/start_screen.dart
+++ b/lib/screen/start/start_screen.dart
@@ -1,0 +1,16 @@
+import 'package:flutter/material.dart';
+import '../../widgets/template/base_scaffold.dart';
+
+class StartScreen extends StatelessWidget {
+  const StartScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return BaseScaffold(
+      title: 'Start',
+      body: const Center(
+        child: Text('시작 화면'),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
### Motivation
- Make the calendar interactive using a standard calendar widget so dates can be selected and navigated to a detail screen.  
- Standardize the app accent/pink color to `#F7A5A5` for consistent theming.  
- Ensure navigation targets exist so the UI can move between pages even if pages are empty placeholders.  

### Description
- Replaced the custom calendar grid with Flutter's `CalendarDatePicker` and wired date selection state in `lib/screen/main_screen.dart`.  
- Added navigation from the date-row arrow to the day detail route using `Navigator.of(context).pushNamed(Routes.dayDetail)` in `lib/screen/main_screen.dart`.  
- Updated accent/pink color to `0xFFF7A5A5` in `lib/screen/main_screen.dart` and set the app theme seed color to `0xFFF7A5A5` in `lib/app.dart`.  
- Added new routes and basic scaffolded placeholder screens for `start`, `login`, `signup`, `cash-detail`, `day-detail`, and `mypage`, and wired them into `lib/routes/routes.dart` and `lib/routes/app_router.dart` (files added/modified: `lib/screen/start/start_screen.dart`, `lib/screen/auth/login_screen.dart`, `lib/screen/auth/sighup_screen.dart`, `lib/screen/cash/cash_detail__screen.dart`, `lib/screen/day/day_detail__screen.dart`, `lib/screen/my/mypage_screen.dart`).  
- Wired bottom navigation items to push the corresponding routes (`Routes.cashDetail`, `Routes.main`, `Routes.mypage`) and added tappable nav items.  

### Testing
- Attempted to run `flutter --version` but Flutter is not available in the environment so the app and widget behavior could not be executed or UI-tested; no Flutter tests were run.  
- Static verification performed by listing and inspecting modified files and searching for the new color constant (`rg` checks) succeeded locally.  
- Changes were staged and committed as a single update (`Update calendar navigation and placeholders`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697b0661a238832bac91b790d8a3d63e)