### PR TITLE
feat: add Flutter API layer for JWT auth (Dio + secure token storage)

### DIFF
--- a/lib/api/api_client.dart
+++ b/lib/api/api_client.dart
@@ -1,0 +1,24 @@
+import 'package:dio/dio.dart';
+
+import 'api_config.dart';
+import 'auth_interceptor.dart';
+import 'token_storage.dart';
+
+class ApiClient {
+  ApiClient._({required TokenStorage tokenStorage})
+      : tokenStorage = tokenStorage,
+        dio = Dio(
+          BaseOptions(
+            baseUrl: ApiConfig.baseUrl,
+            contentType: Headers.jsonContentType,
+            responseType: ResponseType.json,
+          ),
+        ) {
+    dio.interceptors.add(AuthInterceptor(tokenStorage));
+  }
+
+  final Dio dio;
+  final TokenStorage tokenStorage;
+
+  static final ApiClient instance = ApiClient._(tokenStorage: TokenStorage());
+}

--- a/lib/api/api_config.dart
+++ b/lib/api/api_config.dart
@@ -1,0 +1,11 @@
+class ApiConfig {
+  const ApiConfig._();
+
+  /// `--dart-define=API_BASE_URL=http://10.0.2.2:8080` 형태로 덮어쓸 수 있습니다.
+  static const String baseUrl = String.fromEnvironment(
+    'API_BASE_URL',
+    defaultValue: 'http://localhost:8080',
+  );
+
+  static const String apiPrefix = '/api/v1';
+}

--- a/lib/api/auth_api.dart
+++ b/lib/api/auth_api.dart
@@ -1,0 +1,66 @@
+import 'package:dio/dio.dart';
+
+import 'api_client.dart';
+import 'api_config.dart';
+
+class AuthApi {
+  AuthApi({ApiClient? client}) : _client = client ?? ApiClient.instance;
+
+  final ApiClient _client;
+
+  Future<void> signUp({required String email, required String password}) async {
+    await _client.dio.post(
+      '${ApiConfig.apiPrefix}/auth/signup',
+      data: {
+        'email': email,
+        'password': password,
+      },
+    );
+  }
+
+  Future<String> login({required String email, required String password}) async {
+    final response = await _client.dio.post<Map<String, dynamic>>(
+      '${ApiConfig.apiPrefix}/auth/login',
+      data: {
+        'email': email,
+        'password': password,
+      },
+    );
+
+    final token = _extractToken(response.data);
+    await _client.tokenStorage.saveAccessToken(token);
+    return token;
+  }
+
+  Future<void> logout() {
+    return _client.tokenStorage.clearAccessToken();
+  }
+
+  String _extractToken(Map<String, dynamic>? payload) {
+    if (payload == null) {
+      throw DioException.badResponse(
+        statusCode: 500,
+        requestOptions: RequestOptions(path: '${ApiConfig.apiPrefix}/auth/login'),
+        response: null,
+      );
+    }
+
+    final data = payload['data'];
+    if (data is Map<String, dynamic>) {
+      final token = data['token'];
+      if (token is String && token.isNotEmpty) {
+        return token;
+      }
+    }
+
+    throw DioException.badResponse(
+      statusCode: 500,
+      requestOptions: RequestOptions(path: '${ApiConfig.apiPrefix}/auth/login'),
+      response: Response(
+        requestOptions: RequestOptions(path: '${ApiConfig.apiPrefix}/auth/login'),
+        statusCode: 500,
+        data: payload,
+      ),
+    );
+  }
+}

--- a/lib/api/auth_interceptor.dart
+++ b/lib/api/auth_interceptor.dart
@@ -1,0 +1,21 @@
+import 'package:dio/dio.dart';
+
+import 'token_storage.dart';
+
+class AuthInterceptor extends Interceptor {
+  AuthInterceptor(this._tokenStorage);
+
+  final TokenStorage _tokenStorage;
+
+  @override
+  Future<void> onRequest(
+    RequestOptions options,
+    RequestInterceptorHandler handler,
+  ) async {
+    final token = await _tokenStorage.readAccessToken();
+    if (token != null && token.isNotEmpty) {
+      options.headers['Authorization'] = 'Bearer $token';
+    }
+    handler.next(options);
+  }
+}

--- a/lib/api/token_storage.dart
+++ b/lib/api/token_storage.dart
@@ -1,0 +1,21 @@
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+
+class TokenStorage {
+  TokenStorage({FlutterSecureStorage? storage})
+      : _storage = storage ?? const FlutterSecureStorage();
+
+  static const _accessTokenKey = 'access_token';
+  final FlutterSecureStorage _storage;
+
+  Future<void> saveAccessToken(String token) {
+    return _storage.write(key: _accessTokenKey, value: token);
+  }
+
+  Future<String?> readAccessToken() {
+    return _storage.read(key: _accessTokenKey);
+  }
+
+  Future<void> clearAccessToken() {
+    return _storage.delete(key: _accessTokenKey);
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -34,6 +34,8 @@ dependencies:
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^1.0.8
+  dio: ^5.9.0
+  flutter_secure_storage: ^9.2.4
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
### Motivation
- Centralize API configuration and base URL handling for environment overrides via `--dart-define`. 
- Provide a single network entrypoint that automatically attaches JWT `Authorization` headers. 
- Persist access tokens securely and expose simple auth operations (signup/login/logout) aligned with the backend `/api/v1/auth` contract.

### Description
- Add `lib/api/api_config.dart` with `ApiConfig` that reads `API_BASE_URL` from environment and defines `apiPrefix`.
- Add `lib/api/api_client.dart` which creates a singleton `ApiClient` wrapping `Dio` and registers `AuthInterceptor`.
- Add `lib/api/auth_interceptor.dart` that reads token from `TokenStorage` and injects `Authorization: Bearer ...` into requests.
- Add `lib/api/token_storage.dart` which encapsulates token save/read/clear using `flutter_secure_storage`.
- Add `lib/api/auth_api.dart` implementing `signUp`, `login` (parses the backend envelope and saves token), and `logout`; and update `pubspec.yaml` to include `dio` and `flutter_secure_storage`.

### Testing
- Attempted `flutter pub get` to resolve dependencies but `flutter` was not available in this environment, so dependency installation could not be completed (failed).
- Attempted `dart --version` to validate runtime presence but `dart` was not available in this environment (failed).
- No automated unit or widget tests were added or executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699a792155e4832b8a49e4975e794908)