### PR TITLE
feat(auth): ERD 기반 로그인/회원가입 화면 구현

### DIFF
--- a/lib/app.dart
+++ b/lib/app.dart
@@ -10,7 +10,7 @@ class MyApp extends StatelessWidget {
     return MaterialApp(
       debugShowCheckedModeBanner: false,
       title: 'Cash Diary',
-      initialRoute: Routes.main,
+      initialRoute: Routes.login,
       onGenerateRoute: AppRouter.generateRoute,
       theme: ThemeData(
         colorScheme: ColorScheme.fromSeed(

--- a/lib/screen/auth/login_screen.dart
+++ b/lib/screen/auth/login_screen.dart
@@ -1,15 +1,185 @@
 import 'package:flutter/material.dart';
-import '../../widgets/template/base_scaffold.dart';
 
-class LoginScreen extends StatelessWidget {
+import '../../routes/routes.dart';
+import '../../widgets/template/auth_layout.dart';
+
+class LoginScreen extends StatefulWidget {
   const LoginScreen({super.key});
 
   @override
+  State<LoginScreen> createState() => _LoginScreenState();
+}
+
+class _LoginScreenState extends State<LoginScreen> {
+  final _formKey = GlobalKey<FormState>();
+  final _emailController = TextEditingController();
+  final _passwordController = TextEditingController();
+
+  @override
+  void dispose() {
+    _emailController.dispose();
+    _passwordController.dispose();
+    super.dispose();
+  }
+
+  @override
   Widget build(BuildContext context) {
-    return BaseScaffold(
-      title: 'Login',
-      body: const Center(
-        child: Text('로그인 화면'),
+    return AuthLayout(
+      child: SingleChildScrollView(
+        child: Form(
+          key: _formKey,
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              Align(
+                alignment: Alignment.centerLeft,
+                child: IconButton(
+                  icon: const Icon(Icons.chevron_left, size: 28),
+                  onPressed: () => Navigator.of(context).maybePop(),
+                ),
+              ),
+              const SizedBox(height: 56),
+              const _AuthSymbol(),
+              const SizedBox(height: 54),
+              const _FieldLabel('아이디'),
+              const SizedBox(height: 8),
+              TextFormField(
+                controller: _emailController,
+                keyboardType: TextInputType.emailAddress,
+                decoration: _inputDecoration('이메일을 입력해 주세요.'),
+                validator: (value) {
+                  if (value == null || value.trim().isEmpty) {
+                    return '이메일을 입력해 주세요.';
+                  }
+                  return null;
+                },
+              ),
+              const SizedBox(height: 18),
+              const _FieldLabel('비밀번호'),
+              const SizedBox(height: 8),
+              TextFormField(
+                controller: _passwordController,
+                obscureText: true,
+                decoration: _inputDecoration('비밀번호를 입력해 주세요.'),
+                validator: (value) {
+                  if (value == null || value.trim().isEmpty) {
+                    return '비밀번호를 입력해 주세요.';
+                  }
+                  return null;
+                },
+              ),
+              const SizedBox(height: 34),
+              SizedBox(
+                height: 52,
+                child: ElevatedButton(
+                  style: ElevatedButton.styleFrom(
+                    backgroundColor: const Color(0xFFEFA1A1),
+                    foregroundColor: Colors.white,
+                    shape: RoundedRectangleBorder(
+                      borderRadius: BorderRadius.circular(8),
+                    ),
+                    textStyle: const TextStyle(
+                      fontSize: 26,
+                      fontWeight: FontWeight.w700,
+                    ),
+                  ),
+                  onPressed: () {
+                    if (_formKey.currentState!.validate()) {
+                      Navigator.of(context).pushReplacementNamed(Routes.main);
+                    }
+                  },
+                  child: const Text('로그인'),
+                ),
+              ),
+              const SizedBox(height: 18),
+              Row(
+                mainAxisAlignment: MainAxisAlignment.center,
+                children: [
+                  TextButton(
+                    onPressed: () {},
+                    child: const Text('비밀번호 찾기'),
+                  ),
+                  const SizedBox(width: 20),
+                  TextButton(
+                    onPressed: () {
+                      Navigator.of(context).pushNamed(Routes.signup);
+                    },
+                    child: const Text('회원가입'),
+                  ),
+                ],
+              ),
+              const SizedBox(height: 12),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  InputDecoration _inputDecoration(String hint) {
+    return InputDecoration(
+      hintText: hint,
+      hintStyle: const TextStyle(color: Color(0xFFB1B8C7), fontSize: 14),
+      contentPadding: const EdgeInsets.symmetric(horizontal: 14, vertical: 14),
+      filled: true,
+      fillColor: const Color(0xFFF8F8F8),
+      enabledBorder: OutlineInputBorder(
+        borderRadius: BorderRadius.circular(8),
+        borderSide: const BorderSide(color: Color(0xFFD2D8E2)),
+      ),
+      focusedBorder: OutlineInputBorder(
+        borderRadius: BorderRadius.circular(8),
+        borderSide: const BorderSide(color: Color(0xFFA8B1C0), width: 1.4),
+      ),
+      errorBorder: OutlineInputBorder(
+        borderRadius: BorderRadius.circular(8),
+        borderSide: const BorderSide(color: Colors.redAccent),
+      ),
+      focusedErrorBorder: OutlineInputBorder(
+        borderRadius: BorderRadius.circular(8),
+        borderSide: const BorderSide(color: Colors.redAccent, width: 1.4),
+      ),
+    );
+  }
+}
+
+class _FieldLabel extends StatelessWidget {
+  final String text;
+
+  const _FieldLabel(this.text);
+
+  @override
+  Widget build(BuildContext context) {
+    return Text(
+      text,
+      style: const TextStyle(
+        color: Color(0xFF6A7392),
+        fontWeight: FontWeight.w700,
+        fontSize: 20,
+      ),
+    );
+  }
+}
+
+class _AuthSymbol extends StatelessWidget {
+  const _AuthSymbol();
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Container(
+        width: 110,
+        height: 110,
+        decoration: const BoxDecoration(
+          shape: BoxShape.circle,
+          gradient: LinearGradient(
+            colors: [Color(0xFFF9BDD4), Color(0xFFF5EFB2)],
+            begin: Alignment.topCenter,
+            end: Alignment.bottomCenter,
+          ),
+        ),
+        child: const Icon(Icons.calendar_month_rounded,
+            size: 56, color: Color(0xFF2A4769)),
       ),
     );
   }

--- a/lib/screen/auth/sighup_screen.dart
+++ b/lib/screen/auth/sighup_screen.dart
@@ -1,15 +1,168 @@
 import 'package:flutter/material.dart';
-import '../../widgets/template/base_scaffold.dart';
 
-class SignupScreen extends StatelessWidget {
+import '../../widgets/template/auth_layout.dart';
+
+class SignupScreen extends StatefulWidget {
   const SignupScreen({super.key});
 
   @override
+  State<SignupScreen> createState() => _SignupScreenState();
+}
+
+class _SignupScreenState extends State<SignupScreen> {
+  final _formKey = GlobalKey<FormState>();
+  final _emailController = TextEditingController();
+  final _passwordController = TextEditingController();
+  final _confirmPasswordController = TextEditingController();
+
+  @override
+  void dispose() {
+    _emailController.dispose();
+    _passwordController.dispose();
+    _confirmPasswordController.dispose();
+    super.dispose();
+  }
+
+  @override
   Widget build(BuildContext context) {
-    return BaseScaffold(
-      title: 'Signup',
-      body: const Center(
-        child: Text('회원가입 화면'),
+    return AuthLayout(
+      child: SingleChildScrollView(
+        child: Form(
+          key: _formKey,
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              Align(
+                alignment: Alignment.centerLeft,
+                child: IconButton(
+                  icon: const Icon(Icons.chevron_left, size: 28),
+                  onPressed: () => Navigator.of(context).pop(),
+                ),
+              ),
+              const SizedBox(height: 14),
+              const Text(
+                '회원가입',
+                textAlign: TextAlign.center,
+                style: TextStyle(
+                  color: Color(0xFF4C5672),
+                  fontSize: 30,
+                  fontWeight: FontWeight.w700,
+                ),
+              ),
+              const SizedBox(height: 34),
+              const _FieldLabel('이메일'),
+              const SizedBox(height: 8),
+              TextFormField(
+                controller: _emailController,
+                keyboardType: TextInputType.emailAddress,
+                decoration: _inputDecoration('이메일을 입력해 주세요.'),
+                validator: (value) {
+                  if (value == null || value.trim().isEmpty) {
+                    return '이메일을 입력해 주세요.';
+                  }
+                  return null;
+                },
+              ),
+              const SizedBox(height: 18),
+              const _FieldLabel('비밀번호'),
+              const SizedBox(height: 8),
+              TextFormField(
+                controller: _passwordController,
+                obscureText: true,
+                decoration: _inputDecoration('비밀번호를 입력해 주세요.'),
+                validator: (value) {
+                  if (value == null || value.length < 8) {
+                    return '비밀번호는 8자 이상 입력해 주세요.';
+                  }
+                  return null;
+                },
+              ),
+              const SizedBox(height: 18),
+              const _FieldLabel('비밀번호 확인'),
+              const SizedBox(height: 8),
+              TextFormField(
+                controller: _confirmPasswordController,
+                obscureText: true,
+                decoration: _inputDecoration('비밀번호를 한번 더 입력해 주세요.'),
+                validator: (value) {
+                  if (value != _passwordController.text) {
+                    return '비밀번호가 일치하지 않습니다.';
+                  }
+                  return null;
+                },
+              ),
+              const SizedBox(height: 32),
+              SizedBox(
+                height: 52,
+                child: ElevatedButton(
+                  style: ElevatedButton.styleFrom(
+                    backgroundColor: const Color(0xFFEFA1A1),
+                    foregroundColor: Colors.white,
+                    shape: RoundedRectangleBorder(
+                      borderRadius: BorderRadius.circular(8),
+                    ),
+                  ),
+                  onPressed: () {
+                    if (_formKey.currentState!.validate()) {
+                      ScaffoldMessenger.of(context).showSnackBar(
+                        const SnackBar(content: Text('회원가입이 완료되었습니다.')),
+                      );
+                      Navigator.of(context).pop();
+                    }
+                  },
+                  child: const Text(
+                    '회원가입',
+                    style: TextStyle(fontSize: 24, fontWeight: FontWeight.w700),
+                  ),
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  InputDecoration _inputDecoration(String hint) {
+    return InputDecoration(
+      hintText: hint,
+      hintStyle: const TextStyle(color: Color(0xFFB1B8C7), fontSize: 14),
+      contentPadding: const EdgeInsets.symmetric(horizontal: 14, vertical: 14),
+      filled: true,
+      fillColor: const Color(0xFFF8F8F8),
+      enabledBorder: OutlineInputBorder(
+        borderRadius: BorderRadius.circular(8),
+        borderSide: const BorderSide(color: Color(0xFFD2D8E2)),
+      ),
+      focusedBorder: OutlineInputBorder(
+        borderRadius: BorderRadius.circular(8),
+        borderSide: const BorderSide(color: Color(0xFFA8B1C0), width: 1.4),
+      ),
+      errorBorder: OutlineInputBorder(
+        borderRadius: BorderRadius.circular(8),
+        borderSide: const BorderSide(color: Colors.redAccent),
+      ),
+      focusedErrorBorder: OutlineInputBorder(
+        borderRadius: BorderRadius.circular(8),
+        borderSide: const BorderSide(color: Colors.redAccent, width: 1.4),
+      ),
+    );
+  }
+}
+
+class _FieldLabel extends StatelessWidget {
+  final String text;
+
+  const _FieldLabel(this.text);
+
+  @override
+  Widget build(BuildContext context) {
+    return Text(
+      text,
+      style: const TextStyle(
+        color: Color(0xFF6A7392),
+        fontWeight: FontWeight.w700,
+        fontSize: 18,
       ),
     );
   }

--- a/lib/widgets/template/auth_layout.dart
+++ b/lib/widgets/template/auth_layout.dart
@@ -1,0 +1,33 @@
+import 'package:flutter/material.dart';
+
+class AuthLayout extends StatelessWidget {
+  final Widget child;
+
+  const AuthLayout({
+    super.key,
+    required this.child,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: const Color(0xFFF2F2F2),
+      body: SafeArea(
+        child: Center(
+          child: ConstrainedBox(
+            constraints: const BoxConstraints(maxWidth: 420),
+            child: Container(
+              margin: const EdgeInsets.all(12),
+              padding: const EdgeInsets.symmetric(horizontal: 22, vertical: 20),
+              decoration: BoxDecoration(
+                color: const Color(0xFFF8F8F8),
+                borderRadius: BorderRadius.circular(6),
+              ),
+              child: child,
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
### Motivation
- 로그인/회원가입 화면을 ERD의 `Member(email, password)` 구조와 제공된 디자인 시안에 맞춰 구현해 앱 진입 흐름에서 인증을 처리할 수 있게 하기 위함입니다.
- 인증 화면들에 공통 레이아웃을 도입해 디자인 일관성과 재사용성을 확보하려는 목적입니다.

### Description
- 인증 전용 레이아웃 `AuthLayout`을 `lib/widgets/template/auth_layout.dart`에 추가해 중앙 카드 형태의 프레임을 제공했습니다.
- 로그인 화면을 `lib/screen/auth/login_screen.dart`에 상태 기반 폼으로 구현해 이메일/비밀번호 필수 검증을 추가하고 성공 시 `Routes.main`으로 이동하도록 연결했습니다.
- 회원가입 화면을 `lib/screen/auth/sighup_screen.dart`에 구현해 이메일 검증, 비밀번호 최소 길이(8자) 및 비밀번호 확인 일치 검증을 추가하고 성공 시 스낵바를 표시한 뒤 이전 화면으로 복귀하도록 처리했습니다.
- 앱 초기 라우트를 `lib/app.dart`에서 `Routes.login`으로 변경해 앱 시작 시 인증 화면이 표시되도록 했습니다.

### Testing
- `git diff --check`를 실행해 코드 변경에 대한 기본 체크를 통과했습니다.
- `dart format`와 `flutter analyze`는 실행을 시도했으나 환경에 `dart`/`flutter` 바이너리가 없어 실행되지 않았습니다.
- Playwright를 이용한 스크린샷 시도는 앱 서버가 실행 중이지 않아 `ERR_EMPTY_RESPONSE`로 실패했습니다.
- 변경된 파일들의 정적 차이(`lib/app.dart`, `lib/widgets/template/auth_layout.dart`, `lib/screen/auth/login_screen.dart`, `lib/screen/auth/sighup_screen.dart`)를 확인했습니다.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69afb881d108832b80c4c6d053a2c299)