### PR TITLE
feat: ERD 기반 로그인/회원가입 화면 구현

### DIFF
--- a/lib/app.dart
+++ b/lib/app.dart
@@ -10,7 +10,7 @@ class MyApp extends StatelessWidget {
     return MaterialApp(
       debugShowCheckedModeBanner: false,
       title: 'Cash Diary',
-      initialRoute: Routes.main,
+      initialRoute: Routes.login,
       onGenerateRoute: AppRouter.generateRoute,
       theme: ThemeData(
         colorScheme: ColorScheme.fromSeed(

--- a/lib/screen/auth/login_screen.dart
+++ b/lib/screen/auth/login_screen.dart
@@ -1,16 +1,191 @@
 import 'package:flutter/material.dart';
-import '../../widgets/template/base_scaffold.dart';
 
-class LoginScreen extends StatelessWidget {
+import '../../routes/routes.dart';
+
+class LoginScreen extends StatefulWidget {
   const LoginScreen({super.key});
 
   @override
+  State<LoginScreen> createState() => _LoginScreenState();
+}
+
+class _LoginScreenState extends State<LoginScreen> {
+  // ERD의 Member(email, password) 구조를 반영한 입력 컨트롤러입니다.
+  final TextEditingController _emailController = TextEditingController();
+  final TextEditingController _passwordController = TextEditingController();
+
+  @override
+  void dispose() {
+    _emailController.dispose();
+    _passwordController.dispose();
+    super.dispose();
+  }
+
+  @override
   Widget build(BuildContext context) {
-    return BaseScaffold(
-      title: 'Login',
-      body: const Center(
-        child: Text('로그인 화면'),
+    return Scaffold(
+      backgroundColor: const Color(0xFFF5F5F5),
+      body: SafeArea(
+        child: Center(
+          child: Container(
+            width: 360,
+            height: 760,
+            margin: const EdgeInsets.symmetric(vertical: 12),
+            padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 20),
+            decoration: BoxDecoration(
+              color: const Color(0xFFF7F7F7),
+              border: Border.all(color: const Color(0xFFE7E7E7)),
+            ),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                IconButton(
+                  onPressed: () => Navigator.of(context).maybePop(),
+                  icon: const Icon(Icons.chevron_left, size: 28),
+                  padding: EdgeInsets.zero,
+                  constraints: const BoxConstraints(),
+                ),
+                const Spacer(flex: 2),
+                const Center(child: _AuthSymbol()),
+                const Spacer(flex: 2),
+                const Text(
+                  '아이디',
+                  style: TextStyle(
+                    color: Color(0xFF7886A8),
+                    fontWeight: FontWeight.w700,
+                  ),
+                ),
+                const SizedBox(height: 8),
+                _AuthInput(
+                  controller: _emailController,
+                  hintText: '이메일을 입력해 주세요.',
+                ),
+                const SizedBox(height: 18),
+                const Text(
+                  '비밀번호',
+                  style: TextStyle(
+                    color: Color(0xFF7886A8),
+                    fontWeight: FontWeight.w700,
+                  ),
+                ),
+                const SizedBox(height: 8),
+                _AuthInput(
+                  controller: _passwordController,
+                  hintText: '비밀번호를 입력해 주세요.',
+                  obscureText: true,
+                ),
+                const SizedBox(height: 36),
+                SizedBox(
+                  width: double.infinity,
+                  height: 54,
+                  child: ElevatedButton(
+                    style: ElevatedButton.styleFrom(
+                      backgroundColor: const Color(0xFFF3A3A4),
+                      foregroundColor: Colors.white,
+                      shape: RoundedRectangleBorder(
+                        borderRadius: BorderRadius.circular(8),
+                      ),
+                      elevation: 0,
+                    ),
+                    onPressed: () {
+                      // 데모에서는 메인으로 이동만 수행하고, 이후 API 연동 포인트로 사용합니다.
+                      Navigator.of(context).pushReplacementNamed(Routes.main);
+                    },
+                    child: const Text(
+                      '로그인',
+                      style: TextStyle(fontSize: 24, fontWeight: FontWeight.w700),
+                    ),
+                  ),
+                ),
+                const SizedBox(height: 18),
+                Row(
+                  mainAxisAlignment: MainAxisAlignment.center,
+                  children: [
+                    TextButton(
+                      onPressed: () {},
+                      child: const Text(
+                        '비밀번호 찾기',
+                        style: TextStyle(color: Color(0xFFB4BAC8)),
+                      ),
+                    ),
+                    const SizedBox(width: 16),
+                    TextButton(
+                      onPressed: () {
+                        Navigator.of(context).pushNamed(Routes.signup);
+                      },
+                      child: const Text(
+                        '회원가입',
+                        style: TextStyle(color: Color(0xFFB4BAC8)),
+                      ),
+                    ),
+                  ],
+                ),
+                const Spacer(flex: 4),
+              ],
+            ),
+          ),
+        ),
       ),
+    );
+  }
+}
+
+class _AuthInput extends StatelessWidget {
+  final TextEditingController controller;
+  final String hintText;
+  final bool obscureText;
+
+  const _AuthInput({
+    required this.controller,
+    required this.hintText,
+    this.obscureText = false,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return TextField(
+      controller: controller,
+      obscureText: obscureText,
+      decoration: InputDecoration(
+        hintText: hintText,
+        hintStyle: const TextStyle(color: Color(0xFFB4BAC8)),
+        filled: true,
+        fillColor: const Color(0xFFF7F7F7),
+        contentPadding: const EdgeInsets.symmetric(horizontal: 14, vertical: 14),
+        border: OutlineInputBorder(
+          borderRadius: BorderRadius.circular(8),
+          borderSide: const BorderSide(color: Color(0xFFD2D7E2)),
+        ),
+        enabledBorder: OutlineInputBorder(
+          borderRadius: BorderRadius.circular(8),
+          borderSide: const BorderSide(color: Color(0xFFD2D7E2)),
+        ),
+        focusedBorder: OutlineInputBorder(
+          borderRadius: BorderRadius.circular(8),
+          borderSide: const BorderSide(color: Color(0xFFF3A3A4), width: 1.2),
+        ),
+      ),
+    );
+  }
+}
+
+class _AuthSymbol extends StatelessWidget {
+  const _AuthSymbol();
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      width: 96,
+      height: 96,
+      decoration: const BoxDecoration(
+        shape: BoxShape.circle,
+        gradient: LinearGradient(
+          colors: [Color(0xFFE0A7FF), Color(0xFFF9E89A)],
+          begin: Alignment.topCenter,
+          end: Alignment.bottomCenter,
+        ),
+      ),
+      child: const Icon(Icons.calendar_month_outlined, size: 50, color: Color(0xFF2F4B7C)),
     );
   }
 }

--- a/lib/screen/auth/sighup_screen.dart
+++ b/lib/screen/auth/sighup_screen.dart
@@ -1,15 +1,126 @@
 import 'package:flutter/material.dart';
-import '../../widgets/template/base_scaffold.dart';
 
-class SignupScreen extends StatelessWidget {
+import '../../routes/routes.dart';
+
+class SignupScreen extends StatefulWidget {
   const SignupScreen({super.key});
 
   @override
+  State<SignupScreen> createState() => _SignupScreenState();
+}
+
+class _SignupScreenState extends State<SignupScreen> {
+  // ERD의 Member 테이블 스키마(email, password)에 맞춰 가입 폼을 구성합니다.
+  final TextEditingController _emailController = TextEditingController();
+  final TextEditingController _passwordController = TextEditingController();
+  final TextEditingController _passwordConfirmController = TextEditingController();
+
+  @override
+  void dispose() {
+    _emailController.dispose();
+    _passwordController.dispose();
+    _passwordConfirmController.dispose();
+    super.dispose();
+  }
+
+  void _submitSignup() {
+    final password = _passwordController.text;
+    final passwordConfirm = _passwordConfirmController.text;
+
+    // 비밀번호 확인이 일치하지 않으면 가입 요청 대신 안내 메시지를 보여줍니다.
+    if (password != passwordConfirm) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('비밀번호가 일치하지 않습니다.')),
+      );
+      return;
+    }
+
+    ScaffoldMessenger.of(context).showSnackBar(
+      const SnackBar(content: Text('회원가입이 완료되었습니다. 로그인해 주세요.')),
+    );
+
+    Navigator.of(context).pushReplacementNamed(Routes.login);
+  }
+
+  @override
   Widget build(BuildContext context) {
-    return BaseScaffold(
-      title: 'Signup',
-      body: const Center(
-        child: Text('회원가입 화면'),
+    return Scaffold(
+      backgroundColor: const Color(0xFFF5F5F5),
+      appBar: AppBar(
+        backgroundColor: const Color(0xFFF5F5F5),
+        elevation: 0,
+        title: const Text('회원가입'),
+      ),
+      body: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 20),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            const Text('이메일'),
+            const SizedBox(height: 8),
+            _SignupInput(controller: _emailController, hintText: 'example@cashdiary.com'),
+            const SizedBox(height: 16),
+            const Text('비밀번호'),
+            const SizedBox(height: 8),
+            _SignupInput(
+              controller: _passwordController,
+              hintText: '비밀번호를 입력해 주세요.',
+              obscureText: true,
+            ),
+            const SizedBox(height: 16),
+            const Text('비밀번호 확인'),
+            const SizedBox(height: 8),
+            _SignupInput(
+              controller: _passwordConfirmController,
+              hintText: '비밀번호를 다시 입력해 주세요.',
+              obscureText: true,
+            ),
+            const SizedBox(height: 28),
+            SizedBox(
+              width: double.infinity,
+              height: 50,
+              child: ElevatedButton(
+                onPressed: _submitSignup,
+                style: ElevatedButton.styleFrom(
+                  backgroundColor: const Color(0xFFF3A3A4),
+                  foregroundColor: Colors.white,
+                  shape: RoundedRectangleBorder(
+                    borderRadius: BorderRadius.circular(8),
+                  ),
+                  elevation: 0,
+                ),
+                child: const Text('회원가입 완료'),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _SignupInput extends StatelessWidget {
+  final TextEditingController controller;
+  final String hintText;
+  final bool obscureText;
+
+  const _SignupInput({
+    required this.controller,
+    required this.hintText,
+    this.obscureText = false,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return TextField(
+      controller: controller,
+      obscureText: obscureText,
+      decoration: InputDecoration(
+        hintText: hintText,
+        border: OutlineInputBorder(
+          borderRadius: BorderRadius.circular(8),
+        ),
+        contentPadding: const EdgeInsets.symmetric(horizontal: 12, vertical: 12),
       ),
     );
   }


### PR DESCRIPTION
### Motivation
- ERD의 `Member(email, password)` 구조에 맞춰 앱 진입점에서 인증 흐름을 제공하기 위해 로그인/회원가입 UI를 구현했습니다.
- 참고 디자인(심볼, 입력 필드, 버튼, 하단 액션 등)에 맞춘 화면 프레임을 재현해 초기 사용자 경험을 정리하려는 목적입니다.

### Description
- 로그인 화면을 `StatefulWidget`으로 구현하고 이메일/비밀번호 입력을 위한 `TextEditingController`를 추가했으며 UI는 참고 디자인을 반영해 구성했습니다 (`lib/screen/auth/login_screen.dart`).
- 회원가입 화면을 `StatefulWidget`으로 추가해 이메일/비밀번호/비밀번호 확인 필드를 제공하고 비밀번호 일치 검증 후 로그인 화면으로 복귀하는 흐름을 구현했습니다 (`lib/screen/auth/sighup_screen.dart`).
- 앱 초기 진입 라우트를 로그인 화면으로 변경해 앱 실행 시 인증 화면이 먼저 보이도록 조정했습니다 (`lib/app.dart`).
- 기존 `BaseScaffold` 사용 대신 직접 `Scaffold`/레이아웃을 구성하고, 중앙 심볼(`_AuthSymbol`)과 커스텀 입력 위젯(`_AuthInput`, `_SignupInput`)을 도입했습니다.

### Testing
- `flutter format` 및 `flutter analyze`를 시도했으나 이 환경에 Flutter SDK가 없어 실행되지 않았습니다 (명령 실패).
- 웹 스크린샷을 위한 자동 브라우저 캡처를 시도했으나 로컬 서버 미실행으로 접속 실패하여 캡처에 실패했습니다.
- 코드 변경은 로컬 편집과 정적 확인 후 통합할 수 있도록 준비되어 있으며, Flutter SDK가 있는 환경에서 `flutter format` 및 `flutter analyze` 실행으로 추가 검증을 권장합니다.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69afbeb40580832789bff795b391691f)