### PR TITLE
feat: 로그인 화면/달력 가시성 개선 및 마이페이지 UI 추가

### DIFF
--- a/lib/routes/app_router.dart
+++ b/lib/routes/app_router.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/material.dart';
-import 'routes.dart';
+
 import '../screen/auth/login_screen.dart';
 import '../screen/auth/sighup_screen.dart';
 import '../screen/cash/cash_detail__screen.dart';
@@ -7,43 +7,33 @@ import '../screen/day/day_detail__screen.dart';
 import '../screen/main_screen.dart';
 import '../screen/my/mypage_screen.dart';
 import '../screen/start/start_screen.dart';
+import 'routes.dart';
 
 class AppRouter {
   static Route<dynamic> generateRoute(RouteSettings settings) {
+    // ✅ 로그인 이메일 전달을 위해 라우트 arguments를 공통 파싱
+    final args = settings.arguments;
+    final loginEmail = args is Map<String, dynamic> ? (args['loginEmail'] as String? ?? '') : '';
+
     switch (settings.name) {
       case Routes.start:
-        return MaterialPageRoute(
-          builder: (_) => const StartScreen(),
-          settings: settings,
-        );
+        return MaterialPageRoute(builder: (_) => const StartScreen(), settings: settings);
       case Routes.login:
-        return MaterialPageRoute(
-          builder: (_) => const LoginScreen(),
-          settings: settings,
-        );
+        return MaterialPageRoute(builder: (_) => const LoginScreen(), settings: settings);
       case Routes.signup:
-        return MaterialPageRoute(
-          builder: (_) => const SignupScreen(),
-          settings: settings,
-        );
+        return MaterialPageRoute(builder: (_) => const SignupScreen(), settings: settings);
       case Routes.main:
         return MaterialPageRoute(
-          builder: (_) => const MainScreen(),
+          builder: (_) => MainScreen(loginEmail: loginEmail),
           settings: settings,
         );
       case Routes.dayDetail:
-        return MaterialPageRoute(
-          builder: (_) => const DayDetailScreen(),
-          settings: settings,
-        );
+        return MaterialPageRoute(builder: (_) => const DayDetailScreen(), settings: settings);
       case Routes.cashDetail:
-        return MaterialPageRoute(
-          builder: (_) => const CashDetailScreen(),
-          settings: settings,
-        );
+        return MaterialPageRoute(builder: (_) => const CashDetailScreen(), settings: settings);
       case Routes.mypage:
         return MaterialPageRoute(
-          builder: (_) => const MyPageScreen(),
+          builder: (_) => MyPageScreen(loginEmail: loginEmail),
           settings: settings,
         );
 
@@ -62,9 +52,6 @@ class _PlaceholderScreen extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
-      appBar: AppBar(title: Text(title)),
-      body: Center(child: Text('Route: $title')),
-    );
+    return Scaffold(appBar: AppBar(title: Text(title)), body: Center(child: Text('Route: $title')));
   }
 }

--- a/lib/screen/auth/login_screen.dart
+++ b/lib/screen/auth/login_screen.dart
@@ -26,103 +26,97 @@ class _LoginScreenState extends State<LoginScreen> {
     return Scaffold(
       backgroundColor: const Color(0xFFF5F5F5),
       body: SafeArea(
-        child: Center(
-          child: Container(
-            width: 360,
-            height: 760,
-            margin: const EdgeInsets.symmetric(vertical: 12),
-            padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 20),
-            decoration: BoxDecoration(
-              color: const Color(0xFFF7F7F7),
-              border: Border.all(color: const Color(0xFFE7E7E7)),
-            ),
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                IconButton(
-                  onPressed: () => Navigator.of(context).maybePop(),
-                  icon: const Icon(Icons.chevron_left, size: 28),
-                  padding: EdgeInsets.zero,
-                  constraints: const BoxConstraints(),
+        // ✅ 요구사항 반영: 카드 박스가 아닌 "화면 전체"를 쓰는 로그인 레이아웃
+        child: Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 18, vertical: 10),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              IconButton(
+                onPressed: () => Navigator.of(context).maybePop(),
+                icon: const Icon(Icons.chevron_left, size: 28),
+                padding: EdgeInsets.zero,
+                constraints: const BoxConstraints(),
+              ),
+              const SizedBox(height: 44),
+              const Center(child: _AuthSymbol()),
+              const SizedBox(height: 42),
+              const Text(
+                '아이디',
+                style: TextStyle(
+                  color: Color(0xFF7886A8),
+                  fontWeight: FontWeight.w700,
                 ),
-                const Spacer(flex: 2),
-                const Center(child: _AuthSymbol()),
-                const Spacer(flex: 2),
-                const Text(
-                  '아이디',
-                  style: TextStyle(
-                    color: Color(0xFF7886A8),
-                    fontWeight: FontWeight.w700,
-                  ),
+              ),
+              const SizedBox(height: 8),
+              _AuthInput(
+                controller: _emailController,
+                hintText: '이메일을 입력해 주세요.',
+              ),
+              const SizedBox(height: 18),
+              const Text(
+                '비밀번호',
+                style: TextStyle(
+                  color: Color(0xFF7886A8),
+                  fontWeight: FontWeight.w700,
                 ),
-                const SizedBox(height: 8),
-                _AuthInput(
-                  controller: _emailController,
-                  hintText: '이메일을 입력해 주세요.',
-                ),
-                const SizedBox(height: 18),
-                const Text(
-                  '비밀번호',
-                  style: TextStyle(
-                    color: Color(0xFF7886A8),
-                    fontWeight: FontWeight.w700,
-                  ),
-                ),
-                const SizedBox(height: 8),
-                _AuthInput(
-                  controller: _passwordController,
-                  hintText: '비밀번호를 입력해 주세요.',
-                  obscureText: true,
-                ),
-                const SizedBox(height: 36),
-                SizedBox(
-                  width: double.infinity,
-                  height: 54,
-                  child: ElevatedButton(
-                    style: ElevatedButton.styleFrom(
-                      backgroundColor: const Color(0xFFF3A3A4),
-                      foregroundColor: Colors.white,
-                      shape: RoundedRectangleBorder(
-                        borderRadius: BorderRadius.circular(8),
-                      ),
-                      elevation: 0,
+              ),
+              const SizedBox(height: 8),
+              _AuthInput(
+                controller: _passwordController,
+                hintText: '비밀번호를 입력해 주세요.',
+                obscureText: true,
+              ),
+              const SizedBox(height: 24),
+              SizedBox(
+                width: double.infinity,
+                height: 54,
+                child: ElevatedButton(
+                  style: ElevatedButton.styleFrom(
+                    backgroundColor: const Color(0xFFF3A3A4),
+                    foregroundColor: Colors.white,
+                    shape: RoundedRectangleBorder(
+                      borderRadius: BorderRadius.circular(8),
                     ),
+                    elevation: 0,
+                  ),
+                  onPressed: () {
+                    // ✅ 로그인 시 입력한 email을 Main/MyPage로 전달합니다.
+                    Navigator.of(context).pushReplacementNamed(
+                      Routes.main,
+                      arguments: {'loginEmail': _emailController.text.trim()},
+                    );
+                  },
+                  child: const Text(
+                    '로그인',
+                    style: TextStyle(fontSize: 24, fontWeight: FontWeight.w700),
+                  ),
+                ),
+              ),
+              const SizedBox(height: 18),
+              Row(
+                mainAxisAlignment: MainAxisAlignment.center,
+                children: [
+                  TextButton(
+                    onPressed: () {},
+                    child: const Text(
+                      '비밀번호 찾기',
+                      style: TextStyle(color: Color(0xFFB4BAC8)),
+                    ),
+                  ),
+                  const SizedBox(width: 16),
+                  TextButton(
                     onPressed: () {
-                      // 데모에서는 메인으로 이동만 수행하고, 이후 API 연동 포인트로 사용합니다.
-                      Navigator.of(context).pushReplacementNamed(Routes.main);
+                      Navigator.of(context).pushNamed(Routes.signup);
                     },
                     child: const Text(
-                      '로그인',
-                      style: TextStyle(fontSize: 24, fontWeight: FontWeight.w700),
+                      '회원가입',
+                      style: TextStyle(color: Color(0xFFB4BAC8)),
                     ),
                   ),
-                ),
-                const SizedBox(height: 18),
-                Row(
-                  mainAxisAlignment: MainAxisAlignment.center,
-                  children: [
-                    TextButton(
-                      onPressed: () {},
-                      child: const Text(
-                        '비밀번호 찾기',
-                        style: TextStyle(color: Color(0xFFB4BAC8)),
-                      ),
-                    ),
-                    const SizedBox(width: 16),
-                    TextButton(
-                      onPressed: () {
-                        Navigator.of(context).pushNamed(Routes.signup);
-                      },
-                      child: const Text(
-                        '회원가입',
-                        style: TextStyle(color: Color(0xFFB4BAC8)),
-                      ),
-                    ),
-                  ],
-                ),
-                const Spacer(flex: 4),
-              ],
-            ),
+                ],
+              ),
+            ],
           ),
         ),
       ),
@@ -185,7 +179,11 @@ class _AuthSymbol extends StatelessWidget {
           end: Alignment.bottomCenter,
         ),
       ),
-      child: const Icon(Icons.calendar_month_outlined, size: 50, color: Color(0xFF2F4B7C)),
+      child: const Icon(
+        Icons.calendar_month_outlined,
+        size: 50,
+        color: Color(0xFF2F4B7C),
+      ),
     );
   }
 }

--- a/lib/screen/main_screen.dart
+++ b/lib/screen/main_screen.dart
@@ -1,8 +1,12 @@
 import 'package:flutter/material.dart';
+
 import '../routes/routes.dart';
 
 class MainScreen extends StatefulWidget {
-  const MainScreen({super.key});
+  // ✅ 로그인 화면에서 전달된 이메일을 받아 MyPage에 전달하기 위한 필드
+  final String loginEmail;
+
+  const MainScreen({super.key, this.loginEmail = ''});
 
   @override
   State<MainScreen> createState() => _MainScreenState();
@@ -17,16 +21,8 @@ class _MainScreenState extends State<MainScreen> {
   _MainTab _selectedTab = _MainTab.schedule;
 
   final List<_ScheduleItem> _scheduleItems = [
-    _ScheduleItem(
-      label: '아침 운동',
-      timeRange: '07:00 - 09:30',
-      color: _primaryPink,
-    ),
-    _ScheduleItem(
-      label: '친구 약속',
-      timeRange: '11:00 - 15:30',
-      color: const Color(0xFF1F1F1F),
-    ),
+    _ScheduleItem(label: '아침 운동', timeRange: '07:00 - 09:30', color: _primaryPink),
+    _ScheduleItem(label: '친구 약속', timeRange: '11:00 - 15:30', color: const Color(0xFF1F1F1F)),
   ];
 
   final List<_AccountRecord> _records = [
@@ -44,13 +40,15 @@ class _MainScreenState extends State<MainScreen> {
 
   DatePickerThemeData _buildDatePickerTheme() {
     return DatePickerThemeData(
-      // ✅ 선택된 날짜: 핑크 원형 + 흰 글자 (Flutter 3.35: WidgetStateProperty)
+      // ✅ 선택된 날짜: 불투명한 원형 배경 + 진한 글자색으로 가시성 개선
       dayBackgroundColor: WidgetStateProperty.resolveWith((states) {
-        if (states.contains(WidgetState.selected)) return _primaryPink;
+        if (states.contains(WidgetState.selected)) {
+          return _primaryPink.withValues(alpha: 0.45);
+        }
         return null;
       }),
       dayForegroundColor: WidgetStateProperty.resolveWith((states) {
-        if (states.contains(WidgetState.selected)) return Colors.white;
+        if (states.contains(WidgetState.selected)) return Colors.black87;
         if (states.contains(WidgetState.disabled)) return Colors.black26;
         return Colors.black87;
       }),
@@ -58,11 +56,10 @@ class _MainScreenState extends State<MainScreen> {
       // ✅ 오늘 날짜: 핑크 테두리 + 글자색
       todayBorder: const BorderSide(width: 1.6, color: _primaryPink),
       todayForegroundColor: WidgetStateProperty.resolveWith((states) {
-        if (states.contains(WidgetState.selected)) return Colors.white;
+        if (states.contains(WidgetState.selected)) return Colors.black87;
         return _primaryPink;
       }),
 
-      // ✅ 요일/일자/헤더 스타일(선택 색 가시성에 도움)
       weekdayStyle: const TextStyle(fontSize: 11, color: Colors.black54),
       dayStyle: const TextStyle(fontSize: 12, fontWeight: FontWeight.w500),
       headerForegroundColor: Colors.black87,
@@ -74,7 +71,7 @@ class _MainScreenState extends State<MainScreen> {
     final themed = Theme.of(context).copyWith(
       colorScheme: Theme.of(context).colorScheme.copyWith(
         primary: _primaryPink,
-        onPrimary: Colors.white,
+        onPrimary: Colors.black87,
         onSurface: Colors.black87,
       ),
       datePickerTheme: _buildDatePickerTheme(),
@@ -86,18 +83,12 @@ class _MainScreenState extends State<MainScreen> {
         child: Column(
           children: [
             const SizedBox(height: 24),
-            Text(
-              _userName,
-              style: const TextStyle(fontSize: 20, fontWeight: FontWeight.w600),
-            ),
+            Text(_userName, style: const TextStyle(fontSize: 20, fontWeight: FontWeight.w600)),
             const SizedBox(height: 12),
             Expanded(
               child: Container(
                 margin: const EdgeInsets.symmetric(horizontal: 24),
-                padding: const EdgeInsets.symmetric(
-                  horizontal: 16,
-                  vertical: 18,
-                ),
+                padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 18),
                 decoration: BoxDecoration(
                   color: Colors.white,
                   borderRadius: BorderRadius.circular(24),
@@ -115,14 +106,12 @@ class _MainScreenState extends State<MainScreen> {
                     Theme(
                       data: themed,
                       child: CalendarDatePicker(
-                        initialDate: _initialDate,
+                        initialDate: _selectedDate,
                         firstDate: DateTime(2020),
                         lastDate: DateTime(2030),
-
-                        // ✅ 선택 날짜 넣지 말고 "진짜 오늘"만 넣기
                         currentDate: DateTime.now(),
-
                         onDateChanged: (date) {
+                          // ✅ 선택 일자 상태를 갱신하여 하단 날짜 텍스트도 동기화
                           setState(() => _selectedDate = date);
                         },
                       ),
@@ -133,19 +122,14 @@ class _MainScreenState extends State<MainScreen> {
                       children: [
                         Text(
                           _formatDate(_selectedDate),
-                          style: const TextStyle(
-                            fontSize: 14,
-                            fontWeight: FontWeight.w600,
-                          ),
+                          style: const TextStyle(fontSize: 14, fontWeight: FontWeight.w600),
                         ),
                         Row(
                           children: [
                             IconButton(
                               icon: const Icon(Icons.chevron_right, size: 18),
                               onPressed: () {
-                                Navigator.of(
-                                  context,
-                                ).pushNamed(Routes.dayDetail);
+                                Navigator.of(context).pushNamed(Routes.dayDetail);
                               },
                             ),
                             const Icon(Icons.notifications_none, size: 18),
@@ -168,7 +152,7 @@ class _MainScreenState extends State<MainScreen> {
               ),
             ),
             const SizedBox(height: 16),
-            _BottomNavBar(primaryPink: _primaryPink),
+            _BottomNavBar(primaryPink: _primaryPink, loginEmail: widget.loginEmail),
           ],
         ),
       ),
@@ -183,10 +167,7 @@ class _MainScreenState extends State<MainScreen> {
         return [..._todoItems.map((item) => _TodoItemTile(item: item))];
       case _MainTab.consumption:
         return [
-          const Text(
-            '오늘의 소비',
-            style: TextStyle(fontSize: 13, fontWeight: FontWeight.w600),
-          ),
+          const Text('오늘의 소비', style: TextStyle(fontSize: 13, fontWeight: FontWeight.w600)),
           const SizedBox(height: 8),
           ..._records.map((record) => _AccountRecordTile(record: record)),
         ];
@@ -201,11 +182,7 @@ class _CategoryTabs extends StatelessWidget {
   final _MainTab selectedTab;
   final ValueChanged<_MainTab> onTabSelected;
 
-  const _CategoryTabs({
-    required this.primaryPink,
-    required this.selectedTab,
-    required this.onTabSelected,
-  });
+  const _CategoryTabs({required this.primaryPink, required this.selectedTab, required this.onTabSelected});
 
   @override
   Widget build(BuildContext context) {
@@ -242,12 +219,7 @@ class _TabChip extends StatelessWidget {
   final Color activeColor;
   final VoidCallback onTap;
 
-  const _TabChip({
-    required this.label,
-    required this.isActive,
-    required this.activeColor,
-    required this.onTap,
-  });
+  const _TabChip({required this.label, required this.isActive, required this.activeColor, required this.onTap});
 
   @override
   Widget build(BuildContext context) {
@@ -257,10 +229,7 @@ class _TabChip extends StatelessWidget {
         padding: const EdgeInsets.symmetric(horizontal: 2, vertical: 6),
         decoration: BoxDecoration(
           border: Border(
-            bottom: BorderSide(
-              color: isActive ? activeColor : Colors.transparent,
-              width: 2,
-            ),
+            bottom: BorderSide(color: isActive ? activeColor : Colors.transparent, width: 2),
           ),
         ),
         child: Text(
@@ -285,25 +254,15 @@ class _ScheduleCard extends StatelessWidget {
     return Container(
       margin: const EdgeInsets.only(bottom: 8),
       padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
-      decoration: BoxDecoration(
-        color: item.color,
-        borderRadius: BorderRadius.circular(12),
-      ),
+      decoration: BoxDecoration(color: item.color, borderRadius: BorderRadius.circular(12)),
       child: Row(
         mainAxisAlignment: MainAxisAlignment.spaceBetween,
         children: [
           Text(
             item.label,
-            style: TextStyle(
-              color: item.textColor,
-              fontSize: 12,
-              fontWeight: FontWeight.w600,
-            ),
+            style: TextStyle(color: item.textColor, fontSize: 12, fontWeight: FontWeight.w600),
           ),
-          Text(
-            item.timeRange,
-            style: TextStyle(color: item.textColor, fontSize: 11),
-          ),
+          Text(item.timeRange, style: TextStyle(color: item.textColor, fontSize: 11)),
         ],
       ),
     );
@@ -316,35 +275,21 @@ class _AccountRecordTile extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final amountText = record.amount >= 0
-        ? '+${record.amount}'
-        : '${record.amount}';
+    final amountText = record.amount >= 0 ? '+${record.amount}' : '${record.amount}';
 
     return Container(
       margin: const EdgeInsets.only(bottom: 6),
       padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
-      decoration: BoxDecoration(
-        color: const Color(0xFFF8F8F8),
-        borderRadius: BorderRadius.circular(10),
-      ),
+      decoration: BoxDecoration(color: const Color(0xFFF8F8F8), borderRadius: BorderRadius.circular(10)),
       child: Row(
         mainAxisAlignment: MainAxisAlignment.spaceBetween,
         children: [
           Column(
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [
-              Text(
-                record.title,
-                style: const TextStyle(
-                  fontSize: 12,
-                  fontWeight: FontWeight.w600,
-                ),
-              ),
+              Text(record.title, style: const TextStyle(fontSize: 12, fontWeight: FontWeight.w600)),
               const SizedBox(height: 2),
-              Text(
-                record.category,
-                style: const TextStyle(fontSize: 10, color: Colors.black54),
-              ),
+              Text(record.category, style: const TextStyle(fontSize: 10, color: Colors.black54)),
             ],
           ),
           Text(
@@ -352,9 +297,7 @@ class _AccountRecordTile extends StatelessWidget {
             style: TextStyle(
               fontSize: 12,
               fontWeight: FontWeight.w600,
-              color: record.amount >= 0
-                  ? const Color(0xFF1B5E20)
-                  : const Color(0xFFB71C1C),
+              color: record.amount >= 0 ? const Color(0xFF1B5E20) : const Color(0xFFB71C1C),
             ),
           ),
         ],
@@ -372,10 +315,7 @@ class _TodoItemTile extends StatelessWidget {
     return Container(
       margin: const EdgeInsets.only(bottom: 6),
       padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
-      decoration: BoxDecoration(
-        color: const Color(0xFFFFEFEF),
-        borderRadius: BorderRadius.circular(10),
-      ),
+      decoration: BoxDecoration(color: const Color(0xFFFFEFEF), borderRadius: BorderRadius.circular(10)),
       child: Row(
         children: [
           Container(
@@ -387,12 +327,7 @@ class _TodoItemTile extends StatelessWidget {
             ),
           ),
           const SizedBox(width: 8),
-          Expanded(
-            child: Text(
-              item.label,
-              style: const TextStyle(fontSize: 12, color: Colors.black87),
-            ),
-          ),
+          Expanded(child: Text(item.label, style: const TextStyle(fontSize: 12, color: Colors.black87))),
         ],
       ),
     );
@@ -401,18 +336,16 @@ class _TodoItemTile extends StatelessWidget {
 
 class _BottomNavBar extends StatelessWidget {
   final Color primaryPink;
+  final String loginEmail;
 
-  const _BottomNavBar({required this.primaryPink});
+  const _BottomNavBar({required this.primaryPink, required this.loginEmail});
 
   @override
   Widget build(BuildContext context) {
     return Container(
       height: 56,
       margin: const EdgeInsets.symmetric(horizontal: 24),
-      decoration: BoxDecoration(
-        color: primaryPink,
-        borderRadius: BorderRadius.circular(20),
-      ),
+      decoration: BoxDecoration(color: primaryPink, borderRadius: BorderRadius.circular(20)),
       child: Row(
         children: [
           _BottomNavItem(
@@ -423,12 +356,12 @@ class _BottomNavBar extends StatelessWidget {
           _BottomNavItem(
             label: 'HOME',
             isActive: true,
-            onTap: () => Navigator.of(context).pushNamed(Routes.main),
+            onTap: () => Navigator.of(context).pushNamed(Routes.main, arguments: {'loginEmail': loginEmail}),
           ),
           _BottomNavItem(
             label: 'MYPAGE',
             isActive: false,
-            onTap: () => Navigator.of(context).pushNamed(Routes.mypage),
+            onTap: () => Navigator.of(context).pushNamed(Routes.mypage, arguments: {'loginEmail': loginEmail}),
           ),
         ],
       ),
@@ -441,11 +374,7 @@ class _BottomNavItem extends StatelessWidget {
   final bool isActive;
   final VoidCallback onTap;
 
-  const _BottomNavItem({
-    required this.label,
-    required this.isActive,
-    required this.onTap,
-  });
+  const _BottomNavItem({required this.label, required this.isActive, required this.onTap});
 
   @override
   Widget build(BuildContext context) {
@@ -462,11 +391,7 @@ class _BottomNavItem extends StatelessWidget {
           margin: const EdgeInsets.symmetric(horizontal: 4, vertical: 8),
           child: Text(
             label,
-            style: const TextStyle(
-              fontSize: 12,
-              fontWeight: FontWeight.w600,
-              color: Colors.white,
-            ),
+            style: const TextStyle(fontSize: 12, fontWeight: FontWeight.w600, color: Colors.white),
           ),
         ),
       ),
@@ -479,14 +404,9 @@ class _ScheduleItem {
   final String timeRange;
   final Color color;
 
-  const _ScheduleItem({
-    required this.label,
-    required this.timeRange,
-    required this.color,
-  });
+  const _ScheduleItem({required this.label, required this.timeRange, required this.color});
 
-  Color get textColor =>
-      color.computeLuminance() < 0.5 ? Colors.white : Colors.black87;
+  Color get textColor => color.computeLuminance() < 0.5 ? Colors.white : Colors.black87;
 }
 
 class _AccountRecord {
@@ -494,11 +414,7 @@ class _AccountRecord {
   final String category;
   final int amount;
 
-  const _AccountRecord({
-    required this.title,
-    required this.category,
-    required this.amount,
-  });
+  const _AccountRecord({required this.title, required this.category, required this.amount});
 }
 
 class _TodoItem {

--- a/lib/screen/my/mypage_screen.dart
+++ b/lib/screen/my/mypage_screen.dart
@@ -1,15 +1,173 @@
 import 'package:flutter/material.dart';
-import '../../widgets/template/base_scaffold.dart';
 
 class MyPageScreen extends StatelessWidget {
-  const MyPageScreen({super.key});
+  final String loginEmail;
+
+  const MyPageScreen({super.key, this.loginEmail = ''});
 
   @override
   Widget build(BuildContext context) {
-    return BaseScaffold(
-      title: 'My Page',
-      body: const Center(
-        child: Text('마이페이지'),
+    // ✅ 로그인 이메일을 id처럼 활용하기 위해 @ 앞부분을 이름으로 변환
+    final displayId = loginEmail.isEmpty ? '김' : loginEmail.split('@').first;
+    final displayEmail = loginEmail.isEmpty ? 'email.com' : loginEmail;
+
+    return Scaffold(
+      backgroundColor: const Color(0xFFF1F1F1),
+      body: SafeArea(
+        child: Column(
+          children: [
+            Container(
+              height: 44,
+              color: const Color(0xFFFBEFEF),
+              child: Row(
+                children: [
+                  IconButton(
+                    icon: const Icon(Icons.chevron_left, color: Color(0xFFE59A9A)),
+                    onPressed: () => Navigator.of(context).maybePop(),
+                  ),
+                  const Expanded(
+                    child: Text(
+                      'MY PAGE',
+                      textAlign: TextAlign.center,
+                      style: TextStyle(fontWeight: FontWeight.w700, color: Color(0xFF4F5E82)),
+                    ),
+                  ),
+                  const SizedBox(width: 48),
+                ],
+              ),
+            ),
+            Expanded(
+              child: Padding(
+                padding: const EdgeInsets.symmetric(horizontal: 18, vertical: 16),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Row(
+                      children: [
+                        Container(
+                          width: 48,
+                          height: 48,
+                          decoration: const BoxDecoration(
+                            color: Color(0xFF242424),
+                            shape: BoxShape.circle,
+                          ),
+                          alignment: Alignment.center,
+                          child: Text(
+                            displayId.isEmpty ? '김' : displayId.substring(0, 1),
+                            style: const TextStyle(color: Colors.white, fontSize: 18),
+                          ),
+                        ),
+                        const SizedBox(width: 12),
+                        Column(
+                          crossAxisAlignment: CrossAxisAlignment.start,
+                          children: [
+                            Text(
+                              displayId,
+                              style: const TextStyle(
+                                fontWeight: FontWeight.w700,
+                                color: Color(0xFF6B6B6B),
+                              ),
+                            ),
+                            const SizedBox(height: 4),
+                            Text(
+                              displayEmail,
+                              style: const TextStyle(color: Color(0xFFBABABA), fontSize: 12),
+                            ),
+                          ],
+                        ),
+                      ],
+                    ),
+                    const SizedBox(height: 26),
+                    const _MenuRow(icon: Icons.access_time_rounded, label: '지출 수단 및 카테고리'),
+                    const _MenuRow(icon: Icons.favorite_border, label: '내 정보 관리'),
+                    const _MenuRow(icon: Icons.settings_outlined, label: '알림 설정'),
+                    const _MenuRow(icon: Icons.help_outline, label: 'FAQ'),
+                    const SizedBox(height: 24),
+                    const _ActionRow(label: '로그아웃', color: Color(0xFF616161)),
+                    const SizedBox(height: 14),
+                    const _ActionRow(label: '탈퇴하기', color: Color(0xFFE58787)),
+                  ],
+                ),
+              ),
+            ),
+            Container(
+              height: 56,
+              margin: const EdgeInsets.fromLTRB(12, 0, 12, 12),
+              decoration: BoxDecoration(
+                color: const Color(0xFFF7A5A5),
+                borderRadius: BorderRadius.circular(4),
+              ),
+              child: const Row(
+                children: [
+                  _BottomMenu(label: 'CASH'),
+                  _BottomMenu(label: 'HOME'),
+                  _BottomMenu(label: 'MYPAGE'),
+                ],
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _MenuRow extends StatelessWidget {
+  final IconData icon;
+  final String label;
+
+  const _MenuRow({required this.icon, required this.label});
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 10),
+      child: Row(
+        children: [
+          Icon(icon, size: 18, color: const Color(0xFF8B97B0)),
+          const SizedBox(width: 12),
+          Text(label, style: const TextStyle(color: Color(0xFF4F4F4F))),
+        ],
+      ),
+    );
+  }
+}
+
+class _ActionRow extends StatelessWidget {
+  final String label;
+  final Color color;
+
+  const _ActionRow({required this.label, required this.color});
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      children: [
+        const Icon(Icons.logout, size: 15, color: Color(0xFF8B97B0)),
+        const SizedBox(width: 12),
+        Text(label, style: TextStyle(color: color, fontWeight: FontWeight.w500)),
+      ],
+    );
+  }
+}
+
+class _BottomMenu extends StatelessWidget {
+  final String label;
+
+  const _BottomMenu({required this.label});
+
+  @override
+  Widget build(BuildContext context) {
+    return Expanded(
+      child: Container(
+        alignment: Alignment.center,
+        decoration: const BoxDecoration(
+          border: Border(right: BorderSide(color: Colors.white54, width: 1)),
+        ),
+        child: Text(
+          label,
+          style: const TextStyle(color: Colors.white, fontSize: 12, fontWeight: FontWeight.w700),
+        ),
       ),
     );
   }


### PR DESCRIPTION
### Motivation
- 달력에서 선택한 날짜가 표시가 잘 안 되는 가시성 문제를 해결하기 위해 선택일 스타일을 더 눈에 띄게 변경했습니다.
- 로그인 화면을 화면 전체에 배치해 요청한 디자인(박스가 아닌 전체 화면)에 맞추기 위해 레이아웃을 조정했습니다.
- 로그인 정보(이메일)를 마이페이지에서 아이디로 사용하도록 흐름을 연결해 사용자 식별을 반영하기 위해 마이페이지 UI를 추가했습니다.

### Description
- 로그인 화면을 카드형 컨테이너에서 전체 SafeArea + Padding 레이아웃으로 변경하고 로그인 버튼 클릭 시 입력한 이메일을 라우트 인자(`loginEmail`)로 전달하도록 구현했습니다 (`lib/screen/auth/login_screen.dart`).
- 메인 화면 달력의 선택 날짜 가시성을 위해 선택일 배경을 반투명 핑크 원형(`_primaryPink.withValues(alpha: 0.45)`)으로 바꾸고 선택 텍스트 색을 진하게 설정했으며 선택일 변경 시 하단 텍스트가 동기화되도록 상태 갱신을 유지했습니다 (`lib/screen/main_screen.dart`).
- 라우터에서 route `arguments`를 파싱해 `loginEmail`을 추출하고 Main/MyPage로 전달하도록 업데이트했습니다 (`lib/routes/app_router.dart`).
- 마이페이지 화면을 새로 추가(디자인 시안 반영)하고 전달된 `loginEmail`에서 @ 앞부분을 아이디로 표시하도록 구현했으며 프로필/메뉴/하단 네비게이션 UI를 구성했습니다 (`lib/screen/my/mypage_screen.dart`).
- 하단 내비게이션과 메인 화면을 연결하여 `loginEmail`이 Main → MyPage로 전달되도록 업데이트했습니다 (`lib/screen/main_screen.dart`).

### Testing
- 코드 포맷 도구 실행을 시도했으나 로컬 환경에 `flutter`/`dart` 실행 도구가 없어 `flutter format` 및 `dart format`은 수행되지 않았습니다 and failed due to missing tools.
- 유닛/위젯 자동화 테스트는 실행하지 않았습니다.
- 변경사항은 정적 확인(컴파일 에러/문법적 오류가 명백히 있는지 확인) 수준으로 검토했으며, 런타임 검증은 로컬 Flutter 환경에서 실행 후 확인이 필요합니다.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ce38407f5c8327bdd1166fad1ed3b4)