### PR TITLE
MyPage: add subpages/routing, logout, and shared bottom nav; remove login back button

### DIFF
--- a/lib/routes/app_router.dart
+++ b/lib/routes/app_router.dart
@@ -4,6 +4,10 @@ import '../screen/auth/login_screen.dart';
 import '../screen/auth/sighup_screen.dart';
 import '../screen/cash/cash_detail__screen.dart';
 import '../screen/day/day_detail__screen.dart';
+import '../screen/day/my_expense_category_screen.dart';
+import '../screen/day/my_faq_screen.dart';
+import '../screen/day/my_notification_setting_screen.dart';
+import '../screen/day/my_profile_manage_screen.dart';
 import '../screen/main_screen.dart';
 import '../screen/my/mypage_screen.dart';
 import '../screen/start/start_screen.dart';
@@ -28,12 +32,40 @@ class AppRouter {
           settings: settings,
         );
       case Routes.dayDetail:
-        return MaterialPageRoute(builder: (_) => const DayDetailScreen(), settings: settings);
+        return MaterialPageRoute(
+          builder: (_) => DayDetailScreen(loginEmail: loginEmail),
+          settings: settings,
+        );
       case Routes.cashDetail:
-        return MaterialPageRoute(builder: (_) => const CashDetailScreen(), settings: settings);
+        return MaterialPageRoute(
+          builder: (_) => CashDetailScreen(loginEmail: loginEmail),
+          settings: settings,
+        );
       case Routes.mypage:
         return MaterialPageRoute(
           builder: (_) => MyPageScreen(loginEmail: loginEmail),
+          settings: settings,
+        );
+
+      // ✅ 마이페이지 메뉴별 상세 화면 라우트
+      case Routes.myExpenseCategory:
+        return MaterialPageRoute(
+          builder: (_) => MyExpenseCategoryScreen(loginEmail: loginEmail),
+          settings: settings,
+        );
+      case Routes.myProfile:
+        return MaterialPageRoute(
+          builder: (_) => MyProfileManageScreen(loginEmail: loginEmail),
+          settings: settings,
+        );
+      case Routes.myNotification:
+        return MaterialPageRoute(
+          builder: (_) => MyNotificationSettingScreen(loginEmail: loginEmail),
+          settings: settings,
+        );
+      case Routes.myFaq:
+        return MaterialPageRoute(
+          builder: (_) => MyFaqScreen(loginEmail: loginEmail),
           settings: settings,
         );
 

--- a/lib/routes/routes.dart
+++ b/lib/routes/routes.dart
@@ -6,4 +6,10 @@ class Routes {
   static const dayDetail = '/day-detail';
   static const cashDetail = '/cash-detail';
   static const mypage = '/mypage';
+
+  // ✅ 마이페이지 각 메뉴 전용 라우트
+  static const myExpenseCategory = '/my/expense-category';
+  static const myProfile = '/my/profile';
+  static const myNotification = '/my/notification';
+  static const myFaq = '/my/faq';
 }

--- a/lib/screen/auth/login_screen.dart
+++ b/lib/screen/auth/login_screen.dart
@@ -32,13 +32,8 @@ class _LoginScreenState extends State<LoginScreen> {
           child: Column(
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [
-              IconButton(
-                onPressed: () => Navigator.of(context).maybePop(),
-                icon: const Icon(Icons.chevron_left, size: 28),
-                padding: EdgeInsets.zero,
-                constraints: const BoxConstraints(),
-              ),
-              const SizedBox(height: 44),
+              // ✅ 요구사항 반영: 로그인 페이지 상단 뒤로가기 버튼 제거
+              const SizedBox(height: 56),
               const Center(child: _AuthSymbol()),
               const SizedBox(height: 42),
               const Text(

--- a/lib/screen/cash/cash_detail__screen.dart
+++ b/lib/screen/cash/cash_detail__screen.dart
@@ -1,15 +1,27 @@
 import 'package:flutter/material.dart';
+
 import '../../widgets/template/base_scaffold.dart';
+import '../../widgets/template/bottom_nav_layout.dart';
 
 class CashDetailScreen extends StatelessWidget {
-  const CashDetailScreen({super.key});
+  final String loginEmail;
+
+  const CashDetailScreen({super.key, this.loginEmail = ''});
 
   @override
   Widget build(BuildContext context) {
     return BaseScaffold(
       title: 'Cash Detail',
-      body: const Center(
-        child: Text('가계부 페이지'),
+      body: Column(
+        children: [
+          const Expanded(
+            child: Center(
+              child: Text('가계부 페이지'),
+            ),
+          ),
+          // ✅ 모든 화면에서 하단 탭을 공통으로 유지
+          BottomNavLayout(loginEmail: loginEmail, currentTab: BottomNavType.cash),
+        ],
       ),
     );
   }

--- a/lib/screen/day/my_expense_category_screen.dart
+++ b/lib/screen/day/my_expense_category_screen.dart
@@ -3,24 +3,24 @@ import 'package:flutter/material.dart';
 import '../../widgets/template/base_scaffold.dart';
 import '../../widgets/template/bottom_nav_layout.dart';
 
-class DayDetailScreen extends StatelessWidget {
+class MyExpenseCategoryScreen extends StatelessWidget {
   final String loginEmail;
 
-  const DayDetailScreen({super.key, this.loginEmail = ''});
+  const MyExpenseCategoryScreen({super.key, this.loginEmail = ''});
 
   @override
   Widget build(BuildContext context) {
     return BaseScaffold(
-      title: 'Day Detail',
+      title: '지출 수단 및 카테고리',
       body: Column(
         children: [
           const Expanded(
             child: Center(
-              child: Text('일정 상세 페이지'),
+              child: Text('지출 수단 및 카테고리 설정 페이지'),
             ),
           ),
-          // ✅ 모든 화면에서 하단 탭을 공통으로 유지
-          BottomNavLayout(loginEmail: loginEmail, currentTab: BottomNavType.home),
+          // ✅ 모든 페이지 공통 하단 탭 바 유지
+          BottomNavLayout(loginEmail: loginEmail, currentTab: BottomNavType.myPage),
         ],
       ),
     );

--- a/lib/screen/day/my_faq_screen.dart
+++ b/lib/screen/day/my_faq_screen.dart
@@ -3,24 +3,24 @@ import 'package:flutter/material.dart';
 import '../../widgets/template/base_scaffold.dart';
 import '../../widgets/template/bottom_nav_layout.dart';
 
-class DayDetailScreen extends StatelessWidget {
+class MyFaqScreen extends StatelessWidget {
   final String loginEmail;
 
-  const DayDetailScreen({super.key, this.loginEmail = ''});
+  const MyFaqScreen({super.key, this.loginEmail = ''});
 
   @override
   Widget build(BuildContext context) {
     return BaseScaffold(
-      title: 'Day Detail',
+      title: 'FAQ',
       body: Column(
         children: [
           const Expanded(
             child: Center(
-              child: Text('일정 상세 페이지'),
+              child: Text('FAQ 페이지'),
             ),
           ),
-          // ✅ 모든 화면에서 하단 탭을 공통으로 유지
-          BottomNavLayout(loginEmail: loginEmail, currentTab: BottomNavType.home),
+          // ✅ 모든 페이지 공통 하단 탭 바 유지
+          BottomNavLayout(loginEmail: loginEmail, currentTab: BottomNavType.myPage),
         ],
       ),
     );

--- a/lib/screen/day/my_notification_setting_screen.dart
+++ b/lib/screen/day/my_notification_setting_screen.dart
@@ -3,24 +3,24 @@ import 'package:flutter/material.dart';
 import '../../widgets/template/base_scaffold.dart';
 import '../../widgets/template/bottom_nav_layout.dart';
 
-class DayDetailScreen extends StatelessWidget {
+class MyNotificationSettingScreen extends StatelessWidget {
   final String loginEmail;
 
-  const DayDetailScreen({super.key, this.loginEmail = ''});
+  const MyNotificationSettingScreen({super.key, this.loginEmail = ''});
 
   @override
   Widget build(BuildContext context) {
     return BaseScaffold(
-      title: 'Day Detail',
+      title: '알림 설정',
       body: Column(
         children: [
           const Expanded(
             child: Center(
-              child: Text('일정 상세 페이지'),
+              child: Text('알림 설정 페이지'),
             ),
           ),
-          // ✅ 모든 화면에서 하단 탭을 공통으로 유지
-          BottomNavLayout(loginEmail: loginEmail, currentTab: BottomNavType.home),
+          // ✅ 모든 페이지 공통 하단 탭 바 유지
+          BottomNavLayout(loginEmail: loginEmail, currentTab: BottomNavType.myPage),
         ],
       ),
     );

--- a/lib/screen/day/my_profile_manage_screen.dart
+++ b/lib/screen/day/my_profile_manage_screen.dart
@@ -3,24 +3,24 @@ import 'package:flutter/material.dart';
 import '../../widgets/template/base_scaffold.dart';
 import '../../widgets/template/bottom_nav_layout.dart';
 
-class DayDetailScreen extends StatelessWidget {
+class MyProfileManageScreen extends StatelessWidget {
   final String loginEmail;
 
-  const DayDetailScreen({super.key, this.loginEmail = ''});
+  const MyProfileManageScreen({super.key, this.loginEmail = ''});
 
   @override
   Widget build(BuildContext context) {
     return BaseScaffold(
-      title: 'Day Detail',
+      title: '내 정보 관리',
       body: Column(
         children: [
           const Expanded(
             child: Center(
-              child: Text('일정 상세 페이지'),
+              child: Text('내 정보 관리 페이지'),
             ),
           ),
-          // ✅ 모든 화면에서 하단 탭을 공통으로 유지
-          BottomNavLayout(loginEmail: loginEmail, currentTab: BottomNavType.home),
+          // ✅ 모든 페이지 공통 하단 탭 바 유지
+          BottomNavLayout(loginEmail: loginEmail, currentTab: BottomNavType.myPage),
         ],
       ),
     );

--- a/lib/screen/main_screen.dart
+++ b/lib/screen/main_screen.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 
 import '../routes/routes.dart';
+import '../widgets/template/bottom_nav_layout.dart';
 
 class MainScreen extends StatefulWidget {
   // ✅ 로그인 화면에서 전달된 이메일을 받아 MyPage에 전달하기 위한 필드
@@ -129,7 +130,10 @@ class _MainScreenState extends State<MainScreen> {
                             IconButton(
                               icon: const Icon(Icons.chevron_right, size: 18),
                               onPressed: () {
-                                Navigator.of(context).pushNamed(Routes.dayDetail);
+                                Navigator.of(context).pushNamed(
+                                  Routes.dayDetail,
+                                  arguments: {'loginEmail': widget.loginEmail},
+                                );
                               },
                             ),
                             const Icon(Icons.notifications_none, size: 18),
@@ -152,7 +156,8 @@ class _MainScreenState extends State<MainScreen> {
               ),
             ),
             const SizedBox(height: 16),
-            _BottomNavBar(primaryPink: _primaryPink, loginEmail: widget.loginEmail),
+            // ✅ 메인/마이페이지/기타 화면에서 같은 하단 탭을 사용합니다.
+            BottomNavLayout(loginEmail: widget.loginEmail, currentTab: BottomNavType.home),
           ],
         ),
       ),
@@ -329,71 +334,6 @@ class _TodoItemTile extends StatelessWidget {
           const SizedBox(width: 8),
           Expanded(child: Text(item.label, style: const TextStyle(fontSize: 12, color: Colors.black87))),
         ],
-      ),
-    );
-  }
-}
-
-class _BottomNavBar extends StatelessWidget {
-  final Color primaryPink;
-  final String loginEmail;
-
-  const _BottomNavBar({required this.primaryPink, required this.loginEmail});
-
-  @override
-  Widget build(BuildContext context) {
-    return Container(
-      height: 56,
-      margin: const EdgeInsets.symmetric(horizontal: 24),
-      decoration: BoxDecoration(color: primaryPink, borderRadius: BorderRadius.circular(20)),
-      child: Row(
-        children: [
-          _BottomNavItem(
-            label: 'CASH',
-            isActive: false,
-            onTap: () => Navigator.of(context).pushNamed(Routes.cashDetail),
-          ),
-          _BottomNavItem(
-            label: 'HOME',
-            isActive: true,
-            onTap: () => Navigator.of(context).pushNamed(Routes.main, arguments: {'loginEmail': loginEmail}),
-          ),
-          _BottomNavItem(
-            label: 'MYPAGE',
-            isActive: false,
-            onTap: () => Navigator.of(context).pushNamed(Routes.mypage, arguments: {'loginEmail': loginEmail}),
-          ),
-        ],
-      ),
-    );
-  }
-}
-
-class _BottomNavItem extends StatelessWidget {
-  final String label;
-  final bool isActive;
-  final VoidCallback onTap;
-
-  const _BottomNavItem({required this.label, required this.isActive, required this.onTap});
-
-  @override
-  Widget build(BuildContext context) {
-    return Expanded(
-      child: InkWell(
-        borderRadius: BorderRadius.circular(14),
-        onTap: onTap,
-        child: Container(
-          alignment: Alignment.center,
-          decoration: BoxDecoration(
-            color: isActive ? const Color(0xFFF7A5A5) : Colors.transparent,
-            borderRadius: BorderRadius.circular(14),
-          ),
-          margin: const EdgeInsets.symmetric(horizontal: 4, vertical: 8),
-          child: Text(
-            label,
-            style: const TextStyle(fontSize: 12, fontWeight: FontWeight.w600, color: Colors.white),
-          ),
-        ),
       ),
     );
   }

--- a/lib/screen/my/mypage_screen.dart
+++ b/lib/screen/my/mypage_screen.dart
@@ -1,5 +1,8 @@
 import 'package:flutter/material.dart';
 
+import '../../routes/routes.dart';
+import '../../widgets/template/bottom_nav_layout.dart';
+
 class MyPageScreen extends StatelessWidget {
   final String loginEmail;
 
@@ -7,7 +10,7 @@ class MyPageScreen extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    // ✅ 로그인 이메일을 id처럼 활용하기 위해 @ 앞부분을 이름으로 변환
+    // ✅ 로그인 이메일을 아이디/이메일 표시에 재사용합니다.
     final displayId = loginEmail.isEmpty ? '김' : loginEmail.split('@').first;
     final displayEmail = loginEmail.isEmpty ? 'email.com' : loginEmail;
 
@@ -19,21 +22,15 @@ class MyPageScreen extends StatelessWidget {
             Container(
               height: 44,
               color: const Color(0xFFFBEFEF),
-              child: Row(
-                children: [
-                  IconButton(
-                    icon: const Icon(Icons.chevron_left, color: Color(0xFFE59A9A)),
-                    onPressed: () => Navigator.of(context).maybePop(),
+              child: const Center(
+                child: Text(
+                  'MY PAGE',
+                  textAlign: TextAlign.center,
+                  style: TextStyle(
+                    fontWeight: FontWeight.w700,
+                    color: Color(0xFF4F5E82),
                   ),
-                  const Expanded(
-                    child: Text(
-                      'MY PAGE',
-                      textAlign: TextAlign.center,
-                      style: TextStyle(fontWeight: FontWeight.w700, color: Color(0xFF4F5E82)),
-                    ),
-                  ),
-                  const SizedBox(width: 48),
-                ],
+                ),
               ),
             ),
             Expanded(
@@ -71,39 +68,72 @@ class MyPageScreen extends StatelessWidget {
                             const SizedBox(height: 4),
                             Text(
                               displayEmail,
-                              style: const TextStyle(color: Color(0xFFBABABA), fontSize: 12),
+                              style: const TextStyle(
+                                color: Color(0xFFBABABA),
+                                fontSize: 12,
+                              ),
                             ),
                           ],
                         ),
                       ],
                     ),
                     const SizedBox(height: 26),
-                    const _MenuRow(icon: Icons.access_time_rounded, label: '지출 수단 및 카테고리'),
-                    const _MenuRow(icon: Icons.favorite_border, label: '내 정보 관리'),
-                    const _MenuRow(icon: Icons.settings_outlined, label: '알림 설정'),
-                    const _MenuRow(icon: Icons.help_outline, label: 'FAQ'),
+                    _MenuRow(
+                      icon: Icons.access_time_rounded,
+                      label: '지출 수단 및 카테고리',
+                      onTap: () => Navigator.of(context).pushNamed(
+                        Routes.myExpenseCategory,
+                        arguments: {'loginEmail': loginEmail},
+                      ),
+                    ),
+                    _MenuRow(
+                      icon: Icons.favorite_border,
+                      label: '내 정보 관리',
+                      onTap: () => Navigator.of(context).pushNamed(
+                        Routes.myProfile,
+                        arguments: {'loginEmail': loginEmail},
+                      ),
+                    ),
+                    _MenuRow(
+                      icon: Icons.settings_outlined,
+                      label: '알림 설정',
+                      onTap: () => Navigator.of(context).pushNamed(
+                        Routes.myNotification,
+                        arguments: {'loginEmail': loginEmail},
+                      ),
+                    ),
+                    _MenuRow(
+                      icon: Icons.help_outline,
+                      label: 'FAQ',
+                      onTap: () => Navigator.of(context).pushNamed(
+                        Routes.myFaq,
+                        arguments: {'loginEmail': loginEmail},
+                      ),
+                    ),
                     const SizedBox(height: 24),
-                    const _ActionRow(label: '로그아웃', color: Color(0xFF616161)),
+                    _ActionRow(
+                      label: '로그아웃',
+                      color: const Color(0xFF616161),
+                      onTap: () {
+                        // ✅ 로그아웃 시 로그인 페이지만 남기고 스택을 정리합니다.
+                        Navigator.of(context).pushNamedAndRemoveUntil(
+                          Routes.login,
+                          (route) => false,
+                        );
+                      },
+                    ),
                     const SizedBox(height: 14),
-                    const _ActionRow(label: '탈퇴하기', color: Color(0xFFE58787)),
+                    const _ActionRow(
+                      label: '탈퇴하기',
+                      color: Color(0xFFE58787),
+                    ),
                   ],
                 ),
               ),
             ),
-            Container(
-              height: 56,
-              margin: const EdgeInsets.fromLTRB(12, 0, 12, 12),
-              decoration: BoxDecoration(
-                color: const Color(0xFFF7A5A5),
-                borderRadius: BorderRadius.circular(4),
-              ),
-              child: const Row(
-                children: [
-                  _BottomMenu(label: 'CASH'),
-                  _BottomMenu(label: 'HOME'),
-                  _BottomMenu(label: 'MYPAGE'),
-                ],
-              ),
+            BottomNavLayout(
+              loginEmail: loginEmail,
+              currentTab: BottomNavType.myPage,
             ),
           ],
         ),
@@ -115,19 +145,33 @@ class MyPageScreen extends StatelessWidget {
 class _MenuRow extends StatelessWidget {
   final IconData icon;
   final String label;
+  final VoidCallback onTap;
 
-  const _MenuRow({required this.icon, required this.label});
+  const _MenuRow({
+    required this.icon,
+    required this.label,
+    required this.onTap,
+  });
 
   @override
   Widget build(BuildContext context) {
-    return Padding(
-      padding: const EdgeInsets.symmetric(vertical: 10),
-      child: Row(
-        children: [
-          Icon(icon, size: 18, color: const Color(0xFF8B97B0)),
-          const SizedBox(width: 12),
-          Text(label, style: const TextStyle(color: Color(0xFF4F4F4F))),
-        ],
+    return InkWell(
+      onTap: onTap,
+      child: Padding(
+        padding: const EdgeInsets.symmetric(vertical: 10),
+        child: Row(
+          children: [
+            Icon(icon, size: 18, color: const Color(0xFF8B97B0)),
+            const SizedBox(width: 12),
+            Expanded(
+              child: Text(
+                label,
+                style: const TextStyle(color: Color(0xFF4F4F4F)),
+              ),
+            ),
+            const Icon(Icons.chevron_right, size: 16, color: Color(0xFFB0B8C8)),
+          ],
+        ),
       ),
     );
   }
@@ -136,38 +180,20 @@ class _MenuRow extends StatelessWidget {
 class _ActionRow extends StatelessWidget {
   final String label;
   final Color color;
+  final VoidCallback? onTap;
 
-  const _ActionRow({required this.label, required this.color});
-
-  @override
-  Widget build(BuildContext context) {
-    return Row(
-      children: [
-        const Icon(Icons.logout, size: 15, color: Color(0xFF8B97B0)),
-        const SizedBox(width: 12),
-        Text(label, style: TextStyle(color: color, fontWeight: FontWeight.w500)),
-      ],
-    );
-  }
-}
-
-class _BottomMenu extends StatelessWidget {
-  final String label;
-
-  const _BottomMenu({required this.label});
+  const _ActionRow({required this.label, required this.color, this.onTap});
 
   @override
   Widget build(BuildContext context) {
-    return Expanded(
-      child: Container(
-        alignment: Alignment.center,
-        decoration: const BoxDecoration(
-          border: Border(right: BorderSide(color: Colors.white54, width: 1)),
-        ),
-        child: Text(
-          label,
-          style: const TextStyle(color: Colors.white, fontSize: 12, fontWeight: FontWeight.w700),
-        ),
+    return InkWell(
+      onTap: onTap,
+      child: Row(
+        children: [
+          const Icon(Icons.logout, size: 15, color: Color(0xFF8B97B0)),
+          const SizedBox(width: 12),
+          Text(label, style: TextStyle(color: color, fontWeight: FontWeight.w500)),
+        ],
       ),
     );
   }

--- a/lib/widgets/template/bottom_nav_layout.dart
+++ b/lib/widgets/template/bottom_nav_layout.dart
@@ -1,0 +1,96 @@
+import 'package:flutter/material.dart';
+
+import '../../routes/routes.dart';
+
+/// 앱 전역에서 재사용하는 하단 탭 바입니다.
+class BottomNavLayout extends StatelessWidget {
+  final String loginEmail;
+  final BottomNavType currentTab;
+
+  const BottomNavLayout({
+    super.key,
+    required this.loginEmail,
+    required this.currentTab,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      height: 56,
+      margin: const EdgeInsets.fromLTRB(24, 0, 24, 16),
+      decoration: BoxDecoration(
+        color: const Color(0xFFF7A5A5),
+        borderRadius: BorderRadius.circular(20),
+      ),
+      child: Row(
+        children: [
+          _BottomNavItem(
+            label: 'CASH',
+            isActive: currentTab == BottomNavType.cash,
+            onTap: () => Navigator.of(context).pushNamed(
+              Routes.cashDetail,
+              arguments: {'loginEmail': loginEmail},
+            ),
+          ),
+          _BottomNavItem(
+            label: 'HOME',
+            isActive: currentTab == BottomNavType.home,
+            onTap: () => Navigator.of(context).pushNamed(
+              Routes.main,
+              arguments: {'loginEmail': loginEmail},
+            ),
+          ),
+          _BottomNavItem(
+            label: 'MYPAGE',
+            isActive: currentTab == BottomNavType.myPage,
+            onTap: () => Navigator.of(context).pushNamed(
+              Routes.mypage,
+              arguments: {'loginEmail': loginEmail},
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+/// 현재 페이지가 어떤 탭에 속하는지 표시하기 위한 타입입니다.
+enum BottomNavType { cash, home, myPage }
+
+class _BottomNavItem extends StatelessWidget {
+  final String label;
+  final bool isActive;
+  final VoidCallback onTap;
+
+  const _BottomNavItem({
+    required this.label,
+    required this.isActive,
+    required this.onTap,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Expanded(
+      child: InkWell(
+        borderRadius: BorderRadius.circular(14),
+        onTap: onTap,
+        child: Container(
+          alignment: Alignment.center,
+          margin: const EdgeInsets.symmetric(horizontal: 4, vertical: 8),
+          decoration: BoxDecoration(
+            color: isActive ? const Color(0xFFF19999) : Colors.transparent,
+            borderRadius: BorderRadius.circular(14),
+          ),
+          child: Text(
+            label,
+            style: const TextStyle(
+              fontSize: 12,
+              fontWeight: FontWeight.w700,
+              color: Colors.white,
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
### Motivation
- Provide navigable, dedicated screens for each MyPage item so tapping a menu opens a corresponding page under `screen/day/` and preserves `loginEmail` across routes. 
- Keep a consistent bottom navigation across Main/MyPage/detail screens by extracting a reusable `BottomNavLayout` component. 
- Enable explicit logout behavior that returns the user to the login screen and clears the navigation stack. 
- 요약(한국어): 로그인 상단 뒤로가기 제거, 마이페이지 항목별 화면 추가/라우팅, 로그아웃 동작 구현, 공통 바텀 네비게이션 분리 및 적용. 

### Description
- Removed the top back `IconButton` from the login screen and adjusted spacing in `lib/screen/auth/login_screen.dart`. 
- Added a reusable bottom navigation widget `BottomNavLayout` and `BottomNavType` in `lib/widgets/template/bottom_nav_layout.dart`. 
- Replaced inline bottom nav in `MainScreen`/MyPage/detail screens with `BottomNavLayout` and threaded `loginEmail` through route arguments for consistency in `lib/screen/main_screen.dart`, `lib/screen/my/mypage_screen.dart`, `lib/screen/day/day_detail__screen.dart`, and `lib/screen/cash/cash_detail__screen.dart`. 
- Created four MyPage subpages under `lib/screen/day/`: `my_expense_category_screen.dart`, `my_profile_manage_screen.dart`, `my_notification_setting_screen.dart`, and `my_faq_screen.dart`, each rendering a simple placeholder and the shared bottom nav. 
- Extended route constants in `lib/routes/routes.dart` and expanded `AppRouter.generateRoute` in `lib/routes/app_router.dart` to include the new MyPage routes and to pass `loginEmail` into the new/detail screens. 
- Made MyPage menu rows touchable and wired them to the new routes, and implemented logout to call `Navigator.of(context).pushNamedAndRemoveUntil(Routes.login, (route) => false)` in `lib/screen/my/mypage_screen.dart`. 

### Testing
- Attempted to run code formatting with `dart format <files>` but `dart` was not available in the environment so formatting could not be executed. 
- Attempted to query Flutter with `flutter --version` but `flutter` was not available in the environment. 
- No automated unit/widget tests were executed in this environment; all modified files were saved to the workspace for manual verification or CI testing.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ce43ce6fe0832792bf9eb8f0bff11f)