### PR TITLE
Add mock backend data and integrate into Main/Cash screens

### DIFF
--- a/lib/data/mock_backend_data.dart
+++ b/lib/data/mock_backend_data.dart
@@ -1,0 +1,228 @@
+import 'package:flutter/material.dart';
+
+/// ERD 기준의 백엔드 계약을 프런트에서 먼저 맞춰보기 위한 임시 데이터 레이어입니다.
+/// TODO(backend): 백엔드 API 연동 완료 후 이 파일의 mock* 컬렉션과 조회 함수를 제거하세요.
+class MockBackendData {
+  const MockBackendData._();
+
+  /// TODO(backend): 로그인/회원 조회 API 응답으로 교체해야 하는 목 회원 데이터입니다.
+  static const Member currentMember = Member(
+    id: 1,
+    email: 'segye@example.com',
+    password: 'mock-password',
+  );
+
+  /// TODO(backend): 결제수단 CRUD API 응답으로 교체해야 하는 목 결제수단 데이터입니다.
+  static const List<PaymentMethod> paymentMethods = [
+    PaymentMethod(id: 1, memberId: 1, name: '체크카드'),
+    PaymentMethod(id: 2, memberId: 1, name: '현금'),
+  ];
+
+  /// TODO(backend): 카테고리 CRUD API 응답으로 교체해야 하는 목 카테고리 데이터입니다.
+  static const List<Category> categories = [
+    Category(id: 1, name: '식비', type: CategoryType.card),
+    Category(id: 2, name: '교통', type: CategoryType.card),
+    Category(id: 3, name: '월급', type: CategoryType.card),
+    Category(id: 4, name: '운동', type: CategoryType.schedule),
+    Category(id: 5, name: '약속', type: CategoryType.schedule),
+  ];
+
+  /// TODO(backend): 일정 CRUD API 응답으로 교체해야 하는 목 일정 데이터입니다.
+  static final List<Schedule> schedules = [
+    Schedule(
+      id: 1,
+      memberId: 1,
+      title: '아침 운동',
+      startTime: _todayAt(hour: 7),
+      endTime: _todayAt(hour: 9, minute: 30),
+    ),
+    Schedule(
+      id: 2,
+      memberId: 1,
+      title: '친구 약속',
+      startTime: _todayAt(hour: 11),
+      endTime: _todayAt(hour: 15, minute: 30),
+    ),
+    Schedule(
+      id: 3,
+      memberId: 1,
+      title: '프로젝트 회의',
+      startTime: _todayAt(dayOffset: 1, hour: 10),
+      endTime: _todayAt(dayOffset: 1, hour: 11),
+    ),
+  ];
+
+  /// TODO(backend): 할 일 CRUD API 응답으로 교체해야 하는 목 할 일 데이터입니다.
+  static const List<Task> tasks = [
+    Task(id: 1, scheduleId: 1, content: '스트레칭 10분', isCompleted: false),
+    Task(id: 2, scheduleId: 1, content: '러닝 30분', isCompleted: true),
+    Task(id: 3, scheduleId: 2, content: '카페 예약 확인', isCompleted: false),
+    Task(id: 4, scheduleId: 3, content: '회의 자료 정리', isCompleted: false),
+  ];
+
+  /// TODO(backend): 수입/지출 CRUD API 응답으로 교체해야 하는 목 가계부 데이터입니다.
+  static final List<AccountRecord> accountRecords = [
+    AccountRecord(
+      id: 1,
+      memberId: 1,
+      amount: 3200000,
+      transactionTime: _todayAt(hour: 9),
+      paymentMethodId: 1,
+      categoryId: 3,
+    ),
+    AccountRecord(
+      id: 2,
+      memberId: 1,
+      amount: -12000,
+      transactionTime: _todayAt(hour: 12, minute: 20),
+      paymentMethodId: 1,
+      categoryId: 1,
+    ),
+    AccountRecord(
+      id: 3,
+      memberId: 1,
+      amount: -3500,
+      transactionTime: _todayAt(hour: 18, minute: 10),
+      paymentMethodId: 2,
+      categoryId: 2,
+    ),
+    AccountRecord(
+      id: 4,
+      memberId: 1,
+      amount: -5600,
+      transactionTime: _todayAt(dayOffset: 1, hour: 8, minute: 40),
+      paymentMethodId: 1,
+      categoryId: 1,
+    ),
+  ];
+
+  static List<Schedule> schedulesByDate(DateTime date) => schedules
+      .where((schedule) => _isSameDate(schedule.startTime, date))
+      .toList();
+
+  static List<Task> tasksByDate(DateTime date) {
+    final scheduleIds = schedulesByDate(date)
+        .map((schedule) => schedule.id)
+        .toSet();
+    return tasks.where((task) => scheduleIds.contains(task.scheduleId)).toList();
+  }
+
+  static List<AccountRecord> accountRecordsByDate(DateTime date) => accountRecords
+      .where((record) => _isSameDate(record.transactionTime, date))
+      .toList();
+
+  static Category categoryById(int categoryId) => categories.firstWhere(
+        (category) => category.id == categoryId,
+        orElse: () =>
+            const Category(id: 0, name: '미분류', type: CategoryType.card),
+      );
+
+  static PaymentMethod paymentMethodById(int paymentMethodId) =>
+      paymentMethods.firstWhere(
+        (method) => method.id == paymentMethodId,
+        orElse: () => const PaymentMethod(id: 0, memberId: 0, name: '미등록'),
+      );
+
+  static DateTime _todayAt({
+    int dayOffset = 0,
+    required int hour,
+    int minute = 0,
+  }) {
+    final now = DateTime.now();
+    return DateTime(now.year, now.month, now.day + dayOffset, hour, minute);
+  }
+
+  static bool _isSameDate(DateTime left, DateTime right) =>
+      left.year == right.year &&
+      left.month == right.month &&
+      left.day == right.day;
+}
+
+class Member {
+  final int id;
+  final String email;
+  final String password;
+
+  const Member({required this.id, required this.email, required this.password});
+
+  String get nickname => email.split('@').first;
+}
+
+class PaymentMethod {
+  final int id;
+  final int memberId;
+  final String name;
+
+  const PaymentMethod({
+    required this.id,
+    required this.memberId,
+    required this.name,
+  });
+}
+
+enum CategoryType { card, schedule }
+
+class Category {
+  final int id;
+  final String name;
+  final CategoryType type;
+
+  const Category({required this.id, required this.name, required this.type});
+}
+
+class Schedule {
+  final int id;
+  final int memberId;
+  final String title;
+  final DateTime startTime;
+  final DateTime endTime;
+
+  const Schedule({
+    required this.id,
+    required this.memberId,
+    required this.title,
+    required this.startTime,
+    required this.endTime,
+  });
+
+  String get timeRange => '${_timeText(startTime)} - ${_timeText(endTime)}';
+
+  static String _timeText(DateTime time) =>
+      '${time.hour.toString().padLeft(2, '0')}:'
+      '${time.minute.toString().padLeft(2, '0')}';
+}
+
+class Task {
+  final int id;
+  final int scheduleId;
+  final String content;
+  final bool isCompleted;
+
+  const Task({
+    required this.id,
+    required this.scheduleId,
+    required this.content,
+    required this.isCompleted,
+  });
+}
+
+class AccountRecord {
+  final int id;
+  final int memberId;
+  final int amount;
+  final DateTime transactionTime;
+  final int paymentMethodId;
+  final int categoryId;
+
+  const AccountRecord({
+    required this.id,
+    required this.memberId,
+    required this.amount,
+    required this.transactionTime,
+    required this.paymentMethodId,
+    required this.categoryId,
+  });
+
+  Color get amountColor =>
+      amount >= 0 ? const Color(0xFF1B5E20) : const Color(0xFFB71C1C);
+}

--- a/lib/screen/cash/cash_detail__screen.dart
+++ b/lib/screen/cash/cash_detail__screen.dart
@@ -1,4 +1,6 @@
 import 'package:flutter/material.dart';
+
+import '../../data/mock_backend_data.dart';
 import '../../widgets/template/base_scaffold.dart';
 
 class CashDetailScreen extends StatelessWidget {
@@ -6,10 +8,100 @@ class CashDetailScreen extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    // TODO(backend): 백엔드 수입/지출 내역 조회 API로 교체해야 하는 목데이터 조회입니다.
+    final records = MockBackendData.accountRecords;
+    final totalIncome = records
+        .where((record) => record.amount > 0)
+        .fold<int>(0, (sum, record) => sum + record.amount);
+    final totalExpense = records
+        .where((record) => record.amount < 0)
+        .fold<int>(0, (sum, record) => sum + record.amount);
+
     return BaseScaffold(
       title: 'Cash Detail',
-      body: const Center(
-        child: Text('가계부 페이지'),
+      body: ListView(
+        padding: const EdgeInsets.all(24),
+        children: [
+          Row(
+            children: [
+              Expanded(child: _SummaryCard(title: '수입', amount: totalIncome)),
+              const SizedBox(width: 12),
+              Expanded(child: _SummaryCard(title: '지출', amount: totalExpense)),
+            ],
+          ),
+          const SizedBox(height: 24),
+          const Text(
+            '수입/지출 내역',
+            style: TextStyle(fontSize: 16, fontWeight: FontWeight.w700),
+          ),
+          const SizedBox(height: 12),
+          ...records.map((record) => _RecordTile(record: record)),
+        ],
+      ),
+    );
+  }
+}
+
+class _SummaryCard extends StatelessWidget {
+  final String title;
+  final int amount;
+
+  const _SummaryCard({required this.title, required this.amount});
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.all(16),
+      decoration: BoxDecoration(
+        color: const Color(0xFFFFEFEF),
+        borderRadius: BorderRadius.circular(14),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            title,
+            style: const TextStyle(fontSize: 12, color: Colors.black54),
+          ),
+          const SizedBox(height: 8),
+          Text(
+            amount.toString(),
+            style: TextStyle(
+              fontSize: 16,
+              fontWeight: FontWeight.w700,
+              color: amount >= 0
+                  ? const Color(0xFF1B5E20)
+                  : const Color(0xFFB71C1C),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _RecordTile extends StatelessWidget {
+  final AccountRecord record;
+
+  const _RecordTile({required this.record});
+
+  @override
+  Widget build(BuildContext context) {
+    final category = MockBackendData.categoryById(record.categoryId);
+    final paymentMethod = MockBackendData.paymentMethodById(record.paymentMethodId);
+
+    return Card(
+      margin: const EdgeInsets.only(bottom: 10),
+      child: ListTile(
+        title: Text(
+          category.name,
+          style: const TextStyle(fontWeight: FontWeight.w600),
+        ),
+        subtitle: Text(paymentMethod.name),
+        trailing: Text(
+          record.amount.toString(),
+          style: TextStyle(fontWeight: FontWeight.w700, color: record.amountColor),
+        ),
       ),
     );
   }

--- a/lib/screen/main_screen.dart
+++ b/lib/screen/main_screen.dart
@@ -1,4 +1,6 @@
 import 'package:flutter/material.dart';
+
+import '../data/mock_backend_data.dart';
 import '../routes/routes.dart';
 
 class MainScreen extends StatefulWidget {
@@ -9,42 +11,21 @@ class MainScreen extends StatefulWidget {
 }
 
 class _MainScreenState extends State<MainScreen> {
-  static const _userName = '세계';
   static const _primaryPink = Color(0xFFF7A5A5);
-  static final DateTime _initialDate = DateTime(2025, 9, 9);
 
-  late DateTime _selectedDate = _initialDate;
+  // 앱에 새로 진입하면 홈 캘린더가 항상 오늘 날짜를 선택하도록 초기화합니다.
+  late DateTime _selectedDate = _dateOnly(DateTime.now());
   _MainTab _selectedTab = _MainTab.schedule;
 
-  final List<_ScheduleItem> _scheduleItems = [
-    _ScheduleItem(
-      label: '아침 운동',
-      timeRange: '07:00 - 09:30',
-      color: _primaryPink,
-    ),
-    _ScheduleItem(
-      label: '친구 약속',
-      timeRange: '11:00 - 15:30',
-      color: const Color(0xFF1F1F1F),
-    ),
-  ];
-
-  final List<_AccountRecord> _records = [
-    _AccountRecord(title: '월급', category: '수입', amount: 3200000),
-    _AccountRecord(title: '점심', category: '지출', amount: -12000),
-    _AccountRecord(title: '교통', category: '지출', amount: -3500),
-  ];
-
-  final List<_TodoItem> _todoItems = [
-    _TodoItem(label: '백준 알고리즘 실버 2문제'),
-    _TodoItem(label: '두잉코딩 영어 1일차'),
-  ];
+  // 시간 값 때문에 같은 날짜 비교가 어긋나지 않도록 날짜만 남깁니다.
+  static DateTime _dateOnly(DateTime date) =>
+      DateTime(date.year, date.month, date.day);
 
   String _formatDate(DateTime date) => '${date.month}월 ${date.day}일';
 
   DatePickerThemeData _buildDatePickerTheme() {
     return DatePickerThemeData(
-      // ✅ 선택된 날짜: 핑크 원형 + 흰 글자 (Flutter 3.35: WidgetStateProperty)
+      // 선택된 날짜는 글씨색만 바꾸지 않고 배경색을 채워 사용자가 선택 이동을 명확히 볼 수 있게 합니다.
       dayBackgroundColor: WidgetStateProperty.resolveWith((states) {
         if (states.contains(WidgetState.selected)) return _primaryPink;
         return null;
@@ -54,15 +35,11 @@ class _MainScreenState extends State<MainScreen> {
         if (states.contains(WidgetState.disabled)) return Colors.black26;
         return Colors.black87;
       }),
-
-      // ✅ 오늘 날짜: 핑크 테두리 + 글자색
-      todayBorder: const BorderSide(width: 1.6, color: _primaryPink),
+      todayBorder: const BorderSide(width: 1.4, color: _primaryPink),
       todayForegroundColor: WidgetStateProperty.resolveWith((states) {
         if (states.contains(WidgetState.selected)) return Colors.white;
         return _primaryPink;
       }),
-
-      // ✅ 요일/일자/헤더 스타일(선택 색 가시성에 도움)
       weekdayStyle: const TextStyle(fontSize: 11, color: Colors.black54),
       dayStyle: const TextStyle(fontSize: 12, fontWeight: FontWeight.w500),
       headerForegroundColor: Colors.black87,
@@ -73,10 +50,10 @@ class _MainScreenState extends State<MainScreen> {
   Widget build(BuildContext context) {
     final themed = Theme.of(context).copyWith(
       colorScheme: Theme.of(context).colorScheme.copyWith(
-        primary: _primaryPink,
-        onPrimary: Colors.white,
-        onSurface: Colors.black87,
-      ),
+            primary: _primaryPink,
+            onPrimary: Colors.white,
+            onSurface: Colors.black87,
+          ),
       datePickerTheme: _buildDatePickerTheme(),
     );
 
@@ -87,7 +64,7 @@ class _MainScreenState extends State<MainScreen> {
           children: [
             const SizedBox(height: 24),
             Text(
-              _userName,
+              MockBackendData.currentMember.nickname,
               style: const TextStyle(fontSize: 20, fontWeight: FontWeight.w600),
             ),
             const SizedBox(height: 12),
@@ -115,15 +92,13 @@ class _MainScreenState extends State<MainScreen> {
                     Theme(
                       data: themed,
                       child: CalendarDatePicker(
-                        initialDate: _initialDate,
+                        // 선택 날짜를 상태로 관리해서 다른 날짜를 누르면 핑크 배경도 해당 날짜로 이동합니다.
+                        initialDate: _selectedDate,
                         firstDate: DateTime(2020),
                         lastDate: DateTime(2030),
-
-                        // ✅ 선택 날짜 넣지 말고 "진짜 오늘"만 넣기
-                        currentDate: DateTime.now(),
-
+                        currentDate: _dateOnly(DateTime.now()),
                         onDateChanged: (date) {
-                          setState(() => _selectedDate = date);
+                          setState(() => _selectedDate = _dateOnly(date));
                         },
                       ),
                     ),
@@ -143,9 +118,10 @@ class _MainScreenState extends State<MainScreen> {
                             IconButton(
                               icon: const Icon(Icons.chevron_right, size: 18),
                               onPressed: () {
-                                Navigator.of(
-                                  context,
-                                ).pushNamed(Routes.dayDetail);
+                                Navigator.of(context).pushNamed(
+                                  Routes.dayDetail,
+                                  arguments: _selectedDate,
+                                );
                               },
                             ),
                             const Icon(Icons.notifications_none, size: 18),
@@ -176,19 +152,28 @@ class _MainScreenState extends State<MainScreen> {
   }
 
   List<Widget> _buildTabContent() {
+    // TODO(backend): 아래 조회는 임시 목데이터 필터링이므로 백엔드 API 호출로 교체해야 합니다.
+    final schedules = MockBackendData.schedulesByDate(_selectedDate);
+    final tasks = MockBackendData.tasksByDate(_selectedDate);
+    final records = MockBackendData.accountRecordsByDate(_selectedDate);
+
     switch (_selectedTab) {
       case _MainTab.schedule:
-        return [..._scheduleItems.map((item) => _ScheduleCard(item: item))];
+        if (schedules.isEmpty) return [_EmptyState(message: '등록된 일정이 없어요')];
+        return schedules
+            .asMap()
+            .entries
+            .map((entry) => _ScheduleCard(schedule: entry.value, index: entry.key))
+            .toList();
       case _MainTab.todo:
-        return [..._todoItems.map((item) => _TodoItemTile(item: item))];
+        if (tasks.isEmpty) return [_EmptyState(message: '등록된 할 일이 없어요')];
+        return tasks.map((task) => _TodoItemTile(task: task)).toList();
       case _MainTab.consumption:
         return [
-          const Text(
-            '오늘의 소비',
-            style: TextStyle(fontSize: 13, fontWeight: FontWeight.w600),
-          ),
+          const Text('오늘의 소비', style: TextStyle(fontSize: 13, fontWeight: FontWeight.w600)),
           const SizedBox(height: 8),
-          ..._records.map((record) => _AccountRecordTile(record: record)),
+          if (records.isEmpty) const _EmptyState(message: '등록된 수입/지출 내역이 없어요'),
+          ...records.map((record) => _AccountRecordTile(record: record)),
         ];
     }
   }
@@ -257,10 +242,7 @@ class _TabChip extends StatelessWidget {
         padding: const EdgeInsets.symmetric(horizontal: 2, vertical: 6),
         decoration: BoxDecoration(
           border: Border(
-            bottom: BorderSide(
-              color: isActive ? activeColor : Colors.transparent,
-              width: 2,
-            ),
+            bottom: BorderSide(color: isActive ? activeColor : Colors.transparent, width: 2),
           ),
         ),
         child: Text(
@@ -277,32 +259,44 @@ class _TabChip extends StatelessWidget {
 }
 
 class _ScheduleCard extends StatelessWidget {
-  final _ScheduleItem item;
-  const _ScheduleCard({required this.item});
+  static const _scheduleColors = [
+    Color(0xFFF7A5A5),
+    Color(0xFF1F1F1F),
+    Color(0xFFFFD1D1),
+  ];
+
+  final Schedule schedule;
+  final int index;
+
+  const _ScheduleCard({required this.schedule, required this.index});
 
   @override
   Widget build(BuildContext context) {
+    final color = _scheduleColors[index % _scheduleColors.length];
+    final textColor =
+        color.computeLuminance() < 0.5 ? Colors.white : Colors.black87;
+
     return Container(
       margin: const EdgeInsets.only(bottom: 8),
       padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
       decoration: BoxDecoration(
-        color: item.color,
+        color: color,
         borderRadius: BorderRadius.circular(12),
       ),
       child: Row(
         mainAxisAlignment: MainAxisAlignment.spaceBetween,
         children: [
           Text(
-            item.label,
+            schedule.title,
             style: TextStyle(
-              color: item.textColor,
+              color: textColor,
               fontSize: 12,
               fontWeight: FontWeight.w600,
             ),
           ),
           Text(
-            item.timeRange,
-            style: TextStyle(color: item.textColor, fontSize: 11),
+            schedule.timeRange,
+            style: TextStyle(color: textColor, fontSize: 11),
           ),
         ],
       ),
@@ -311,14 +305,15 @@ class _ScheduleCard extends StatelessWidget {
 }
 
 class _AccountRecordTile extends StatelessWidget {
-  final _AccountRecord record;
+  final AccountRecord record;
   const _AccountRecordTile({required this.record});
 
   @override
   Widget build(BuildContext context) {
-    final amountText = record.amount >= 0
-        ? '+${record.amount}'
-        : '${record.amount}';
+    final category = MockBackendData.categoryById(record.categoryId);
+    final paymentMethod =
+        MockBackendData.paymentMethodById(record.paymentMethodId);
+    final amountText = record.amount >= 0 ? '+${record.amount}' : '${record.amount}';
 
     return Container(
       margin: const EdgeInsets.only(bottom: 6),
@@ -334,15 +329,12 @@ class _AccountRecordTile extends StatelessWidget {
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [
               Text(
-                record.title,
-                style: const TextStyle(
-                  fontSize: 12,
-                  fontWeight: FontWeight.w600,
-                ),
+                category.name,
+                style: const TextStyle(fontSize: 12, fontWeight: FontWeight.w600),
               ),
               const SizedBox(height: 2),
               Text(
-                record.category,
+                paymentMethod.name,
                 style: const TextStyle(fontSize: 10, color: Colors.black54),
               ),
             ],
@@ -352,9 +344,7 @@ class _AccountRecordTile extends StatelessWidget {
             style: TextStyle(
               fontSize: 12,
               fontWeight: FontWeight.w600,
-              color: record.amount >= 0
-                  ? const Color(0xFF1B5E20)
-                  : const Color(0xFFB71C1C),
+              color: record.amountColor,
             ),
           ),
         ],
@@ -364,8 +354,8 @@ class _AccountRecordTile extends StatelessWidget {
 }
 
 class _TodoItemTile extends StatelessWidget {
-  final _TodoItem item;
-  const _TodoItemTile({required this.item});
+  final Task task;
+  const _TodoItemTile({required this.task});
 
   @override
   Widget build(BuildContext context) {
@@ -382,18 +372,49 @@ class _TodoItemTile extends StatelessWidget {
             width: 14,
             height: 14,
             decoration: BoxDecoration(
+              color: task.isCompleted
+                  ? const Color(0xFFF7A5A5)
+                  : Colors.transparent,
               border: Border.all(color: Colors.black45, width: 1),
               borderRadius: BorderRadius.circular(3),
             ),
+            child: task.isCompleted
+                ? const Icon(Icons.check, size: 10, color: Colors.white)
+                : null,
           ),
           const SizedBox(width: 8),
           Expanded(
             child: Text(
-              item.label,
-              style: const TextStyle(fontSize: 12, color: Colors.black87),
+              task.content,
+              style: TextStyle(
+                fontSize: 12,
+                color: Colors.black87,
+                decoration: task.isCompleted
+                    ? TextDecoration.lineThrough
+                    : TextDecoration.none,
+              ),
             ),
           ),
         ],
+      ),
+    );
+  }
+}
+
+class _EmptyState extends StatelessWidget {
+  final String message;
+
+  const _EmptyState({required this.message});
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 18),
+      child: Center(
+        child: Text(
+          message,
+          style: const TextStyle(fontSize: 12, color: Colors.black45),
+        ),
       ),
     );
   }
@@ -472,37 +493,4 @@ class _BottomNavItem extends StatelessWidget {
       ),
     );
   }
-}
-
-class _ScheduleItem {
-  final String label;
-  final String timeRange;
-  final Color color;
-
-  const _ScheduleItem({
-    required this.label,
-    required this.timeRange,
-    required this.color,
-  });
-
-  Color get textColor =>
-      color.computeLuminance() < 0.5 ? Colors.white : Colors.black87;
-}
-
-class _AccountRecord {
-  final String title;
-  final String category;
-  final int amount;
-
-  const _AccountRecord({
-    required this.title,
-    required this.category,
-    required this.amount,
-  });
-}
-
-class _TodoItem {
-  final String label;
-
-  const _TodoItem({required this.label});
 }

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -1,30 +1,14 @@
-// This is a basic Flutter widget test.
-//
-// To perform an interaction with a widget in your test, use the WidgetTester
-// utility in the flutter_test package. For example, you can send tap and scroll
-// gestures. You can also use WidgetTester to find child widgets in the widget
-// tree, read text, and verify that the values of widget properties are correct.
-
-import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
-
 import 'package:segye_world/app.dart';
 
 void main() {
-  testWidgets('Counter increments smoke test', (WidgetTester tester) async {
-    // Build our app and trigger a frame.
+  testWidgets('홈 화면에 ERD 기반 목데이터가 표시된다', (WidgetTester tester) async {
+    // 메인 라우트로 시작해 회원/일정 목데이터가 홈에 노출되는지 확인합니다.
     await tester.pumpWidget(const MyApp());
+    await tester.pumpAndSettle();
 
-    // Verify that our counter starts at 0.
-    expect(find.text('0'), findsOneWidget);
-    expect(find.text('1'), findsNothing);
-
-    // Tap the '+' icon and trigger a frame.
-    await tester.tap(find.byIcon(Icons.add));
-    await tester.pump();
-
-    // Verify that our counter has incremented.
-    expect(find.text('0'), findsNothing);
-    expect(find.text('1'), findsOneWidget);
+    expect(find.text('segye'), findsOneWidget);
+    expect(find.text('아침 운동'), findsOneWidget);
+    expect(find.text('친구 약속'), findsOneWidget);
   });
 }


### PR DESCRIPTION
### Motivation

- Provide a temporary front-end data layer that matches the ERD so screens can be developed before backend APIs are ready.
- Show realistic schedule, todo, and account data on the home and cash detail screens for UX development and QA.

### Description

- Added `lib/data/mock_backend_data.dart` which contains mock data models (`Member`, `PaymentMethod`, `Category`, `Schedule`, `Task`, `AccountRecord`), sample collections, and helper query functions like `schedulesByDate`, `tasksByDate`, and `accountRecordsByDate`.
- Updated `lib/screen/main_screen.dart` to initialize the calendar to today, normalize date-only comparisons, consume `MockBackendData` for member nickname, schedules, tasks, and records, replace hard-coded demo item classes with real models, add empty-state UI, and refine calendar/date theming and navigation to pass the selected date to the day detail route.
- Updated `lib/screen/cash/cash_detail__screen.dart` to render a cash summary and record list backed by `MockBackendData`, resolving category and payment method names and applying amount coloring.
- Removed local demo-only classes (`_ScheduleItem`, `_AccountRecord`, `_TodoItem`) and replaced usages with real model types, plus small UI improvements (colors, checkboxes, schedule color cycling) and TODO comments to replace mocks with real backend API calls.

### Testing

- Ran the widget test `test/widget_test.dart` which was updated to assert that the home screen displays the mock member nickname and example schedules, and the test passed when executed with `flutter test`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a02c03a84f4832787d9c44399445637)