### PR TITLE
feat: ERD 기반 목데이터 및 홈 날짜 선택 개선

### DIFF
--- a/lib/data/mock_erd_repository.dart
+++ b/lib/data/mock_erd_repository.dart
@@ -1,0 +1,241 @@
+/// ERD 기준으로 프론트에서 사용하는 임시 데이터 모델과 저장소입니다.
+///
+/// 백엔드 연동 시 이 파일의 MockErdRepository 내부 목데이터/메서드를 API 호출 레이어로 교체하세요.
+/// 화면에서는 ERD 필드명과 동일한 모델을 사용하므로 DTO 매핑 비용을 줄일 수 있습니다.
+
+/// 회원(Member) 테이블 모델입니다.
+class Member {
+  final int id;
+  final String email;
+  final String password;
+
+  const Member({required this.id, required this.email, required this.password});
+}
+
+/// 지불수단(PaymentMethod) 테이블 모델입니다.
+class PaymentMethod {
+  final int id;
+  final int memberId;
+  final String name;
+
+  const PaymentMethod({required this.id, required this.memberId, required this.name});
+}
+
+/// 카테고리(Category) 테이블 모델입니다.
+class Category {
+  final int id;
+  final String name;
+  final String type;
+
+  const Category({required this.id, required this.name, required this.type});
+}
+
+/// 일정(Schedule) 테이블 모델입니다.
+class Schedule {
+  final int id;
+  final int memberId;
+  final String title;
+  final DateTime startTime;
+  final DateTime endTime;
+
+  const Schedule({
+    required this.id,
+    required this.memberId,
+    required this.title,
+    required this.startTime,
+    required this.endTime,
+  });
+}
+
+/// 할일(Task) 테이블 모델입니다.
+class Task {
+  final int id;
+  final int scheduleId;
+  final String content;
+  final bool isCompleted;
+
+  const Task({required this.id, required this.scheduleId, required this.content, required this.isCompleted});
+}
+
+/// 수입/지출내역(AccountRecord) 테이블 모델입니다.
+class AccountRecord {
+  final int id;
+  final int memberId;
+  final int? scheduleId;
+  final int categoryId;
+  final int paymentMethodId;
+  final int amount;
+  final DateTime transactionTime;
+
+  const AccountRecord({
+    required this.id,
+    required this.memberId,
+    required this.scheduleId,
+    required this.categoryId,
+    required this.paymentMethodId,
+    required this.amount,
+    required this.transactionTime,
+  });
+}
+
+/// ERD 관계를 화면에서 바로 보여주기 위해 조인한 수입/지출 뷰 모델입니다.
+class AccountRecordView {
+  final AccountRecord record;
+  final Category category;
+  final PaymentMethod paymentMethod;
+  final Schedule? schedule;
+
+  const AccountRecordView({
+    required this.record,
+    required this.category,
+    required this.paymentMethod,
+    required this.schedule,
+  });
+}
+
+/// ERD 관계를 화면에서 바로 보여주기 위해 일정과 할 일을 묶은 뷰 모델입니다.
+class ScheduleWithTasks {
+  final Schedule schedule;
+  final List<Task> tasks;
+
+  const ScheduleWithTasks({required this.schedule, required this.tasks});
+}
+
+/// CRUD 화면이 백엔드 연결 전에도 동작하도록 만든 인메모리 저장소입니다.
+class MockErdRepository {
+  MockErdRepository._();
+
+  static final MockErdRepository instance = MockErdRepository._();
+
+  // TODO(backend): 백엔드 연동 후 아래 목 회원 데이터는 실제 로그인 사용자 응답으로 교체하고 삭제하세요.
+  final List<Member> _members = const [
+    Member(id: 1, email: 'segye@example.com', password: 'mock-password'),
+  ];
+
+  // TODO(backend): 백엔드 연동 후 아래 목 지불수단 데이터는 PaymentMethod API 응답으로 교체하고 삭제하세요.
+  final List<PaymentMethod> _paymentMethods = const [
+    PaymentMethod(id: 1, memberId: 1, name: '체크카드'),
+    PaymentMethod(id: 2, memberId: 1, name: '현금'),
+  ];
+
+  // TODO(backend): 백엔드 연동 후 아래 목 카테고리 데이터는 Category API 응답으로 교체하고 삭제하세요.
+  final List<Category> _categories = const [
+    Category(id: 1, name: '월급', type: 'INCOME'),
+    Category(id: 2, name: '식비', type: 'EXPENSE'),
+    Category(id: 3, name: '교통', type: 'EXPENSE'),
+    Category(id: 4, name: '공부', type: 'CARD'),
+  ];
+
+  // TODO(backend): 백엔드 연동 후 아래 목 일정 데이터는 Schedule CRUD API 응답으로 교체하고 삭제하세요.
+  final List<Schedule> _schedules = [
+    Schedule(
+      id: 1,
+      memberId: 1,
+      title: '아침 운동',
+      startTime: DateTime.now().copyWith(hour: 7, minute: 0, second: 0, millisecond: 0, microsecond: 0),
+      endTime: DateTime.now().copyWith(hour: 9, minute: 30, second: 0, millisecond: 0, microsecond: 0),
+    ),
+    Schedule(
+      id: 2,
+      memberId: 1,
+      title: '친구 약속',
+      startTime: DateTime.now().copyWith(hour: 11, minute: 0, second: 0, millisecond: 0, microsecond: 0),
+      endTime: DateTime.now().copyWith(hour: 15, minute: 30, second: 0, millisecond: 0, microsecond: 0),
+    ),
+    Schedule(
+      id: 3,
+      memberId: 1,
+      title: '내일 회의 준비',
+      startTime: DateTime.now().add(const Duration(days: 1)).copyWith(hour: 10, minute: 0, second: 0, millisecond: 0, microsecond: 0),
+      endTime: DateTime.now().add(const Duration(days: 1)).copyWith(hour: 11, minute: 0, second: 0, millisecond: 0, microsecond: 0),
+    ),
+  ];
+
+  // TODO(backend): 백엔드 연동 후 아래 목 할일 데이터는 Task CRUD API 응답으로 교체하고 삭제하세요.
+  final List<Task> _tasks = const [
+    Task(id: 1, scheduleId: 1, content: '백준 알고리즘 실버 2문제', isCompleted: false),
+    Task(id: 2, scheduleId: 1, content: '두잉코딩 영어 1일차', isCompleted: true),
+    Task(id: 3, scheduleId: 3, content: '회의 자료 초안 작성', isCompleted: false),
+  ];
+
+  // TODO(backend): 백엔드 연동 후 아래 목 수입/지출 데이터는 AccountRecord CRUD API 응답으로 교체하고 삭제하세요.
+  final List<AccountRecord> _accountRecords = [
+    AccountRecord(
+      id: 1,
+      memberId: 1,
+      scheduleId: null,
+      categoryId: 1,
+      paymentMethodId: 1,
+      amount: 3200000,
+      transactionTime: DateTime.now().copyWith(hour: 9, minute: 0, second: 0, millisecond: 0, microsecond: 0),
+    ),
+    AccountRecord(
+      id: 2,
+      memberId: 1,
+      scheduleId: 2,
+      categoryId: 2,
+      paymentMethodId: 1,
+      amount: -12000,
+      transactionTime: DateTime.now().copyWith(hour: 12, minute: 20, second: 0, millisecond: 0, microsecond: 0),
+    ),
+    AccountRecord(
+      id: 3,
+      memberId: 1,
+      scheduleId: null,
+      categoryId: 3,
+      paymentMethodId: 2,
+      amount: -3500,
+      transactionTime: DateTime.now().copyWith(hour: 18, minute: 10, second: 0, millisecond: 0, microsecond: 0),
+    ),
+  ];
+
+  Member get currentMember => _members.first;
+
+  List<Category> get categories => List.unmodifiable(_categories);
+
+  List<PaymentMethod> paymentMethodsByMember(int memberId) =>
+      _paymentMethods.where((method) => method.memberId == memberId).toList(growable: false);
+
+  List<ScheduleWithTasks> schedulesByDate(DateTime date, {int? memberId}) {
+    final targetMemberId = memberId ?? currentMember.id;
+    return _schedules
+        .where((schedule) => schedule.memberId == targetMemberId && _isSameDate(schedule.startTime, date))
+        .map((schedule) {
+          final tasks = _tasks.where((task) => task.scheduleId == schedule.id).toList(growable: false);
+          return ScheduleWithTasks(schedule: schedule, tasks: tasks);
+        })
+        .toList(growable: false);
+  }
+
+  List<Task> tasksByDate(DateTime date, {int? memberId}) => schedulesByDate(date, memberId: memberId)
+      .expand((scheduleWithTasks) => scheduleWithTasks.tasks)
+      .toList(growable: false);
+
+  List<AccountRecordView> accountRecordsByDate(DateTime date, {int? memberId}) {
+    final targetMemberId = memberId ?? currentMember.id;
+    return _accountRecords
+        .where((record) => record.memberId == targetMemberId && _isSameDate(record.transactionTime, date))
+        .map(_toAccountRecordView)
+        .toList(growable: false);
+  }
+
+  List<AccountRecordView> allAccountRecordViews({int? memberId}) {
+    final targetMemberId = memberId ?? currentMember.id;
+    return _accountRecords
+        .where((record) => record.memberId == targetMemberId)
+        .map(_toAccountRecordView)
+        .toList(growable: false);
+  }
+
+  AccountRecordView _toAccountRecordView(AccountRecord record) {
+    final category = _categories.firstWhere((category) => category.id == record.categoryId);
+    final paymentMethod = _paymentMethods.firstWhere((method) => method.id == record.paymentMethodId);
+    final schedule = record.scheduleId == null
+        ? null
+        : _schedules.firstWhere((schedule) => schedule.id == record.scheduleId);
+    return AccountRecordView(record: record, category: category, paymentMethod: paymentMethod, schedule: schedule);
+  }
+
+  bool _isSameDate(DateTime left, DateTime right) =>
+      left.year == right.year && left.month == right.month && left.day == right.day;
+}

--- a/lib/routes/app_router.dart
+++ b/lib/routes/app_router.dart
@@ -18,6 +18,8 @@ class AppRouter {
     // ✅ 로그인 이메일 전달을 위해 라우트 arguments를 공통 파싱
     final args = settings.arguments;
     final loginEmail = args is Map<String, dynamic> ? (args['loginEmail'] as String? ?? '') : '';
+    // ✅ 홈에서 선택한 날짜를 상세 화면으로 전달해 같은 날짜의 CRUD 데이터를 보여줍니다.
+    final selectedDate = args is Map<String, dynamic> ? args['selectedDate'] as DateTime? : null;
 
     switch (settings.name) {
       case Routes.start:
@@ -33,7 +35,7 @@ class AppRouter {
         );
       case Routes.dayDetail:
         return MaterialPageRoute(
-          builder: (_) => DayDetailScreen(loginEmail: loginEmail),
+          builder: (_) => DayDetailScreen(loginEmail: loginEmail, selectedDate: selectedDate),
           settings: settings,
         );
       case Routes.cashDetail:

--- a/lib/screen/cash/cash_detail__screen.dart
+++ b/lib/screen/cash/cash_detail__screen.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 
+import '../../data/mock_erd_repository.dart';
 import '../../widgets/template/base_scaffold.dart';
 import '../../widgets/template/bottom_nav_layout.dart';
 
@@ -10,13 +11,21 @@ class CashDetailScreen extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final records = MockErdRepository.instance.allAccountRecordViews();
+
     return BaseScaffold(
       title: 'Cash Detail',
       body: Column(
         children: [
-          const Expanded(
-            child: Center(
-              child: Text('가계부 페이지'),
+          Expanded(
+            child: ListView(
+              padding: const EdgeInsets.all(20),
+              children: [
+                const Text('수입/지출 내역', style: TextStyle(fontSize: 18, fontWeight: FontWeight.w700)),
+                const SizedBox(height: 12),
+                // ✅ ERD의 AccountRecord와 Category/PaymentMethod/Schedule 조인 결과를 목데이터로 표시합니다.
+                ...records.map((record) => _CashRecordCard(record: record)),
+              ],
             ),
           ),
           // ✅ 모든 화면에서 하단 탭을 공통으로 유지
@@ -26,3 +35,57 @@ class CashDetailScreen extends StatelessWidget {
     );
   }
 }
+
+class _CashRecordCard extends StatelessWidget {
+  final AccountRecordView record;
+
+  const _CashRecordCard({required this.record});
+
+  @override
+  Widget build(BuildContext context) {
+    final amount = record.record.amount;
+    final amountText = amount >= 0 ? '+$amount' : '$amount';
+
+    return Container(
+      margin: const EdgeInsets.only(bottom: 10),
+      padding: const EdgeInsets.all(14),
+      decoration: BoxDecoration(
+        color: Colors.white,
+        borderRadius: BorderRadius.circular(16),
+        boxShadow: [
+          BoxShadow(color: Colors.black.withValues(alpha: 0.05), blurRadius: 10, offset: const Offset(0, 4)),
+        ],
+      ),
+      child: Row(
+        mainAxisAlignment: MainAxisAlignment.spaceBetween,
+        children: [
+          Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text(record.category.name, style: const TextStyle(fontWeight: FontWeight.w700)),
+              const SizedBox(height: 4),
+              Text(
+                '${record.paymentMethod.name} · ${_formatDateTime(record.record.transactionTime)}',
+                style: const TextStyle(fontSize: 12, color: Colors.black54),
+              ),
+              if (record.schedule != null) ...[
+                const SizedBox(height: 4),
+                Text('연결 일정: ${record.schedule!.title}', style: const TextStyle(fontSize: 12, color: Colors.black45)),
+              ],
+            ],
+          ),
+          Text(
+            amountText,
+            style: TextStyle(
+              color: amount >= 0 ? const Color(0xFF1B5E20) : const Color(0xFFB71C1C),
+              fontWeight: FontWeight.w700,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+String _formatDateTime(DateTime time) =>
+    '${time.month}/${time.day} ${time.hour.toString().padLeft(2, '0')}:${time.minute.toString().padLeft(2, '0')}';

--- a/lib/screen/day/day_detail__screen.dart
+++ b/lib/screen/day/day_detail__screen.dart
@@ -1,22 +1,39 @@
 import 'package:flutter/material.dart';
 
+import '../../data/mock_erd_repository.dart';
 import '../../widgets/template/base_scaffold.dart';
 import '../../widgets/template/bottom_nav_layout.dart';
 
 class DayDetailScreen extends StatelessWidget {
   final String loginEmail;
+  final DateTime? selectedDate;
 
-  const DayDetailScreen({super.key, this.loginEmail = ''});
+  const DayDetailScreen({super.key, this.loginEmail = '', this.selectedDate});
 
   @override
   Widget build(BuildContext context) {
+    final date = DateUtils.dateOnly(selectedDate ?? DateTime.now());
+    final schedules = MockErdRepository.instance.schedulesByDate(date);
+
     return BaseScaffold(
       title: 'Day Detail',
       body: Column(
         children: [
-          const Expanded(
-            child: Center(
-              child: Text('일정 상세 페이지'),
+          Expanded(
+            child: ListView(
+              padding: const EdgeInsets.all(20),
+              children: [
+                Text(
+                  '${date.month}월 ${date.day}일 일정',
+                  style: const TextStyle(fontSize: 18, fontWeight: FontWeight.w700),
+                ),
+                const SizedBox(height: 12),
+                // ✅ ERD의 Schedule(일정)과 Task(할일) 관계를 목데이터로 먼저 노출합니다.
+                if (schedules.isEmpty)
+                  const _EmptyDetailCard(message: '선택한 날짜의 일정이 없습니다.')
+                else
+                  ...schedules.map((scheduleWithTasks) => _ScheduleDetailCard(item: scheduleWithTasks)),
+              ],
             ),
           ),
           // ✅ 모든 화면에서 하단 탭을 공통으로 유지
@@ -26,3 +43,73 @@ class DayDetailScreen extends StatelessWidget {
     );
   }
 }
+
+class _ScheduleDetailCard extends StatelessWidget {
+  final ScheduleWithTasks item;
+
+  const _ScheduleDetailCard({required this.item});
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      margin: const EdgeInsets.only(bottom: 12),
+      padding: const EdgeInsets.all(14),
+      decoration: BoxDecoration(
+        color: Colors.white,
+        borderRadius: BorderRadius.circular(16),
+        boxShadow: [
+          BoxShadow(color: Colors.black.withValues(alpha: 0.05), blurRadius: 10, offset: const Offset(0, 4)),
+        ],
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(item.schedule.title, style: const TextStyle(fontSize: 15, fontWeight: FontWeight.w700)),
+          const SizedBox(height: 6),
+          Text(
+            '${_formatTime(item.schedule.startTime)} - ${_formatTime(item.schedule.endTime)}',
+            style: const TextStyle(fontSize: 12, color: Colors.black54),
+          ),
+          const SizedBox(height: 10),
+          if (item.tasks.isEmpty)
+            const Text('연결된 할 일이 없습니다.', style: TextStyle(fontSize: 12, color: Colors.black45))
+          else
+            ...item.tasks.map(
+              (task) => Padding(
+                padding: const EdgeInsets.only(bottom: 6),
+                child: Row(
+                  children: [
+                    Icon(
+                      task.isCompleted ? Icons.check_circle : Icons.radio_button_unchecked,
+                      size: 16,
+                      color: const Color(0xFFF7A5A5),
+                    ),
+                    const SizedBox(width: 6),
+                    Expanded(child: Text(task.content, style: const TextStyle(fontSize: 12))),
+                  ],
+                ),
+              ),
+            ),
+        ],
+      ),
+    );
+  }
+}
+
+class _EmptyDetailCard extends StatelessWidget {
+  final String message;
+
+  const _EmptyDetailCard({required this.message});
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.all(18),
+      decoration: BoxDecoration(color: Colors.white, borderRadius: BorderRadius.circular(16)),
+      child: Text(message, style: const TextStyle(color: Colors.black45)),
+    );
+  }
+}
+
+String _formatTime(DateTime time) =>
+    '${time.hour.toString().padLeft(2, '0')}:${time.minute.toString().padLeft(2, '0')}';

--- a/lib/screen/day/my_expense_category_screen.dart
+++ b/lib/screen/day/my_expense_category_screen.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 
+import '../../data/mock_erd_repository.dart';
 import '../../widgets/template/base_scaffold.dart';
 import '../../widgets/template/bottom_nav_layout.dart';
 
@@ -10,17 +11,75 @@ class MyExpenseCategoryScreen extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final repository = MockErdRepository.instance;
+    final memberId = repository.currentMember.id;
+    final categories = repository.categories;
+    final paymentMethods = repository.paymentMethodsByMember(memberId);
+
     return BaseScaffold(
       title: '지출 수단 및 카테고리',
       body: Column(
         children: [
-          const Expanded(
-            child: Center(
-              child: Text('지출 수단 및 카테고리 설정 페이지'),
+          Expanded(
+            child: ListView(
+              padding: const EdgeInsets.all(20),
+              children: [
+                const _SectionTitle(title: '카테고리'),
+                // ✅ ERD의 Category 데이터를 목데이터로 표시하며, 백엔드 연동 시 실제 CRUD 응답으로 대체됩니다.
+                ...categories.map((category) => _SettingRow(title: category.name, subtitle: category.type)),
+                const SizedBox(height: 20),
+                const _SectionTitle(title: '지불수단'),
+                // ✅ ERD의 PaymentMethod 데이터를 목데이터로 표시하며, 백엔드 연동 시 실제 CRUD 응답으로 대체됩니다.
+                ...paymentMethods.map((method) => _SettingRow(title: method.name, subtitle: 'memberId: ${method.memberId}')),
+              ],
             ),
           ),
           // ✅ 모든 페이지 공통 하단 탭 바 유지
           BottomNavLayout(loginEmail: loginEmail, currentTab: BottomNavType.myPage),
+        ],
+      ),
+    );
+  }
+}
+
+class _SectionTitle extends StatelessWidget {
+  final String title;
+
+  const _SectionTitle({required this.title});
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 8),
+      child: Text(title, style: const TextStyle(fontSize: 16, fontWeight: FontWeight.w700)),
+    );
+  }
+}
+
+class _SettingRow extends StatelessWidget {
+  final String title;
+  final String subtitle;
+
+  const _SettingRow({required this.title, required this.subtitle});
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      margin: const EdgeInsets.only(bottom: 8),
+      padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 12),
+      decoration: BoxDecoration(color: Colors.white, borderRadius: BorderRadius.circular(14)),
+      child: Row(
+        mainAxisAlignment: MainAxisAlignment.spaceBetween,
+        children: [
+          Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text(title, style: const TextStyle(fontWeight: FontWeight.w600)),
+              const SizedBox(height: 3),
+              Text(subtitle, style: const TextStyle(fontSize: 12, color: Colors.black45)),
+            ],
+          ),
+          const Icon(Icons.edit_outlined, size: 16, color: Color(0xFFF7A5A5)),
         ],
       ),
     );

--- a/lib/screen/main_screen.dart
+++ b/lib/screen/main_screen.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 
+import '../data/mock_erd_repository.dart';
 import '../routes/routes.dart';
 import '../widgets/template/bottom_nav_layout.dart';
 
@@ -16,26 +17,17 @@ class MainScreen extends StatefulWidget {
 class _MainScreenState extends State<MainScreen> {
   static const _userName = '세계';
   static const _primaryPink = Color(0xFFF7A5A5);
-  static final DateTime _initialDate = DateTime(2025, 9, 9);
+  final MockErdRepository _repository = MockErdRepository.instance;
 
-  late DateTime _selectedDate = _initialDate;
+  late DateTime _selectedDate;
   _MainTab _selectedTab = _MainTab.schedule;
 
-  final List<_ScheduleItem> _scheduleItems = [
-    _ScheduleItem(label: '아침 운동', timeRange: '07:00 - 09:30', color: _primaryPink),
-    _ScheduleItem(label: '친구 약속', timeRange: '11:00 - 15:30', color: const Color(0xFF1F1F1F)),
-  ];
-
-  final List<_AccountRecord> _records = [
-    _AccountRecord(title: '월급', category: '수입', amount: 3200000),
-    _AccountRecord(title: '점심', category: '지출', amount: -12000),
-    _AccountRecord(title: '교통', category: '지출', amount: -3500),
-  ];
-
-  final List<_TodoItem> _todoItems = [
-    _TodoItem(label: '백준 알고리즘 실버 2문제'),
-    _TodoItem(label: '두잉코딩 영어 1일차'),
-  ];
+  @override
+  void initState() {
+    super.initState();
+    // ✅ 앱에 새로 진입할 때마다 홈 캘린더의 선택 날짜를 오늘로 초기화합니다.
+    _selectedDate = DateUtils.dateOnly(DateTime.now());
+  }
 
   String _formatDate(DateTime date) => '${date.month}월 ${date.day}일';
 
@@ -44,20 +36,22 @@ class _MainScreenState extends State<MainScreen> {
       // ✅ 선택된 날짜: 불투명한 원형 배경 + 진한 글자색으로 가시성 개선
       dayBackgroundColor: WidgetStateProperty.resolveWith((states) {
         if (states.contains(WidgetState.selected)) {
-          return _primaryPink.withValues(alpha: 0.45);
+          // ✅ 선택된 날짜 자체의 배경색을 채워 다른 날짜 선택 시 표시가 함께 이동합니다.
+          return _primaryPink;
         }
         return null;
       }),
       dayForegroundColor: WidgetStateProperty.resolveWith((states) {
-        if (states.contains(WidgetState.selected)) return Colors.black87;
+        if (states.contains(WidgetState.selected)) return Colors.white;
         if (states.contains(WidgetState.disabled)) return Colors.black26;
         return Colors.black87;
       }),
 
       // ✅ 오늘 날짜: 핑크 테두리 + 글자색
       todayBorder: const BorderSide(width: 1.6, color: _primaryPink),
+      dayShape: WidgetStateProperty.all(const CircleBorder()),
       todayForegroundColor: WidgetStateProperty.resolveWith((states) {
-        if (states.contains(WidgetState.selected)) return Colors.black87;
+        if (states.contains(WidgetState.selected)) return Colors.white;
         return _primaryPink;
       }),
 
@@ -110,10 +104,10 @@ class _MainScreenState extends State<MainScreen> {
                         initialDate: _selectedDate,
                         firstDate: DateTime(2020),
                         lastDate: DateTime(2030),
-                        currentDate: DateTime.now(),
+                        currentDate: DateUtils.dateOnly(DateTime.now()),
                         onDateChanged: (date) {
-                          // ✅ 선택 일자 상태를 갱신하여 하단 날짜 텍스트도 동기화
-                          setState(() => _selectedDate = date);
+                          // ✅ 선택 일자 상태를 갱신하여 배경 표시와 하단 CRUD 목록을 모두 동기화합니다.
+                          setState(() => _selectedDate = DateUtils.dateOnly(date));
                         },
                       ),
                     ),
@@ -132,7 +126,7 @@ class _MainScreenState extends State<MainScreen> {
                               onPressed: () {
                                 Navigator.of(context).pushNamed(
                                   Routes.dayDetail,
-                                  arguments: {'loginEmail': widget.loginEmail},
+                                  arguments: {'loginEmail': widget.loginEmail, 'selectedDate': _selectedDate},
                                 );
                               },
                             ),
@@ -165,16 +159,25 @@ class _MainScreenState extends State<MainScreen> {
   }
 
   List<Widget> _buildTabContent() {
+    final schedules = _repository.schedulesByDate(_selectedDate);
+    final tasks = _repository.tasksByDate(_selectedDate);
+    final records = _repository.accountRecordsByDate(_selectedDate);
+
     switch (_selectedTab) {
       case _MainTab.schedule:
-        return [..._scheduleItems.map((item) => _ScheduleCard(item: item))];
+        if (schedules.isEmpty) return [_EmptyState(message: '${_formatDate(_selectedDate)} 일정이 없어요.')];
+        return [...schedules.map((item) => _ScheduleCard(item: item))];
       case _MainTab.todo:
-        return [..._todoItems.map((item) => _TodoItemTile(item: item))];
+        if (tasks.isEmpty) return [_EmptyState(message: '${_formatDate(_selectedDate)} 할 일이 없어요.')];
+        return [...tasks.map((item) => _TodoItemTile(item: item))];
       case _MainTab.consumption:
         return [
-          const Text('오늘의 소비', style: TextStyle(fontSize: 13, fontWeight: FontWeight.w600)),
+          Text('${_formatDate(_selectedDate)} 소비', style: const TextStyle(fontSize: 13, fontWeight: FontWeight.w600)),
           const SizedBox(height: 8),
-          ..._records.map((record) => _AccountRecordTile(record: record)),
+          if (records.isEmpty)
+            _EmptyState(message: '${_formatDate(_selectedDate)} 수입/지출 내역이 없어요.')
+          else
+            ...records.map((record) => _AccountRecordTile(record: record)),
         ];
     }
   }
@@ -251,23 +254,26 @@ class _TabChip extends StatelessWidget {
 }
 
 class _ScheduleCard extends StatelessWidget {
-  final _ScheduleItem item;
+  final ScheduleWithTasks item;
   const _ScheduleCard({required this.item});
 
   @override
   Widget build(BuildContext context) {
+    final timeRange = '${_formatTime(item.schedule.startTime)} - ${_formatTime(item.schedule.endTime)}';
+    final color = item.schedule.id.isOdd ? _MainScreenState._primaryPink : const Color(0xFF1F1F1F);
+    final textColor = color.computeLuminance() < 0.5 ? Colors.white : Colors.black87;
     return Container(
       margin: const EdgeInsets.only(bottom: 8),
       padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
-      decoration: BoxDecoration(color: item.color, borderRadius: BorderRadius.circular(12)),
+      decoration: BoxDecoration(color: color, borderRadius: BorderRadius.circular(12)),
       child: Row(
         mainAxisAlignment: MainAxisAlignment.spaceBetween,
         children: [
           Text(
-            item.label,
-            style: TextStyle(color: item.textColor, fontSize: 12, fontWeight: FontWeight.w600),
+            item.schedule.title,
+            style: TextStyle(color: textColor, fontSize: 12, fontWeight: FontWeight.w600),
           ),
-          Text(item.timeRange, style: TextStyle(color: item.textColor, fontSize: 11)),
+          Text(timeRange, style: TextStyle(color: textColor, fontSize: 11)),
         ],
       ),
     );
@@ -275,12 +281,13 @@ class _ScheduleCard extends StatelessWidget {
 }
 
 class _AccountRecordTile extends StatelessWidget {
-  final _AccountRecord record;
+  final AccountRecordView record;
   const _AccountRecordTile({required this.record});
 
   @override
   Widget build(BuildContext context) {
-    final amountText = record.amount >= 0 ? '+${record.amount}' : '${record.amount}';
+    final amount = record.record.amount;
+    final amountText = amount >= 0 ? '+$amount' : '$amount';
 
     return Container(
       margin: const EdgeInsets.only(bottom: 6),
@@ -292,9 +299,9 @@ class _AccountRecordTile extends StatelessWidget {
           Column(
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [
-              Text(record.title, style: const TextStyle(fontSize: 12, fontWeight: FontWeight.w600)),
+              Text(record.category.name, style: const TextStyle(fontSize: 12, fontWeight: FontWeight.w600)),
               const SizedBox(height: 2),
-              Text(record.category, style: const TextStyle(fontSize: 10, color: Colors.black54)),
+              Text(record.paymentMethod.name, style: const TextStyle(fontSize: 10, color: Colors.black54)),
             ],
           ),
           Text(
@@ -302,7 +309,7 @@ class _AccountRecordTile extends StatelessWidget {
             style: TextStyle(
               fontSize: 12,
               fontWeight: FontWeight.w600,
-              color: record.amount >= 0 ? const Color(0xFF1B5E20) : const Color(0xFFB71C1C),
+              color: amount >= 0 ? const Color(0xFF1B5E20) : const Color(0xFFB71C1C),
             ),
           ),
         ],
@@ -312,7 +319,7 @@ class _AccountRecordTile extends StatelessWidget {
 }
 
 class _TodoItemTile extends StatelessWidget {
-  final _TodoItem item;
+  final Task item;
   const _TodoItemTile({required this.item});
 
   @override
@@ -327,38 +334,34 @@ class _TodoItemTile extends StatelessWidget {
             width: 14,
             height: 14,
             decoration: BoxDecoration(
+              color: item.isCompleted ? const Color(0xFFF7A5A5) : Colors.transparent,
               border: Border.all(color: Colors.black45, width: 1),
               borderRadius: BorderRadius.circular(3),
             ),
           ),
           const SizedBox(width: 8),
-          Expanded(child: Text(item.label, style: const TextStyle(fontSize: 12, color: Colors.black87))),
+          Expanded(child: Text(item.content, style: const TextStyle(fontSize: 12, color: Colors.black87))),
         ],
       ),
     );
   }
 }
 
-class _ScheduleItem {
-  final String label;
-  final String timeRange;
-  final Color color;
+class _EmptyState extends StatelessWidget {
+  final String message;
 
-  const _ScheduleItem({required this.label, required this.timeRange, required this.color});
+  const _EmptyState({required this.message});
 
-  Color get textColor => color.computeLuminance() < 0.5 ? Colors.white : Colors.black87;
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      width: double.infinity,
+      padding: const EdgeInsets.symmetric(vertical: 18),
+      alignment: Alignment.center,
+      child: Text(message, style: const TextStyle(fontSize: 12, color: Colors.black45)),
+    );
+  }
 }
 
-class _AccountRecord {
-  final String title;
-  final String category;
-  final int amount;
-
-  const _AccountRecord({required this.title, required this.category, required this.amount});
-}
-
-class _TodoItem {
-  final String label;
-
-  const _TodoItem({required this.label});
-}
+String _formatTime(DateTime time) =>
+    '${time.hour.toString().padLeft(2, '0')}:${time.minute.toString().padLeft(2, '0')}';


### PR DESCRIPTION
### Motivation
- 프론트쪽 CRUD 화면을 백엔드 연동 전에도 ERD 구조에 맞춘 목데이터로 동작시키고 백엔드 연동 준비를 하기 위함입니다.
- 사용자가 앱에 진입하면 기본으로 오늘 날짜가 선택되도록 해 UX를 개선하고, 다른 날짜 선택 시 해당 날짜의 CRUD 내용으로 화면이 즉시 갱신되도록 하기 위함입니다.
- 선택된 날짜의 표시를 글자색 변경뿐 아니라 배경색으로 명확히 보여주어 가시성을 높이기 위함입니다.

### Description
- ERD 기반 모델과 인메모리 저장소를 추가하여 `Member`, `PaymentMethod`, `Category`, `Schedule`, `Task`, `AccountRecord` 및 조인 뷰 모델 `AccountRecordView`, `ScheduleWithTasks`와 `MockErdRepository`를 `lib/data/mock_erd_repository.dart`에 구현했습니다.
- 홈화면인 `MainScreen`을 수정하여 `initState`에서 `selectedDate`를 오늘로 초기화하고 `MockErdRepository`에서 날짜 기반으로 `schedules/tasks/accountRecords`를 조회해 각 탭의 내용을 렌더링하도록 변경했습니다.
- 캘린더 테마(`DatePickerThemeData`)를 변경해 선택된 날짜의 배경을 채우고 글자색을 흰색으로 바꾸어 선택 표시가 배경색으로 이동하도록 했습니다.
- 홈에서 선택한 `selectedDate`를 라우트 인자에 포함시켜 `DayDetailScreen`으로 전달하도록 라우터를 변경하고(`lib/routes/app_router.dart`), 상세 화면을 `selectedDate`를 받아 해당 날짜의 일정/할 일을 `MockErdRepository`로부터 보여주도록 수정했습니다(`lib/screen/day/day_detail__screen.dart`).
- 가계부 화면을 ERD 조인 뷰(`AccountRecordView`)로 렌더링하도록 변경하고 카드 UI를 추가했으며(`lib/screen/cash/cash_detail__screen.dart`), 지출수단/카테고리 화면도 목데이터를 사용해 목록을 표시하도록 수정했습니다(`lib/screen/day/my_expense_category_screen.dart`).
- 목데이터 영역에는 `// TODO(backend): ...` 주석을 추가해 백엔드 연동 시 교체/삭제할 위치를 명시했습니다.
- 관련 UI 컴포넌트들(`_ScheduleCard`, `_TodoItemTile`, `_AccountRecordTile`, 등)을 ERD 뷰 모델에 맞춰 업데이트했습니다.

### Testing
- `git diff --check`를 실행해 코드 스타일/충돌 관련 문제는 없음을 확인했습니다 (성공).
- `dart format lib/screen/main_screen.dart lib/data/mock_erd_repository.dart` 실행을 시도했으나 실행환경에 `dart` 명령이 없어 수행하지 못했습니다 (미실행).
- `flutter test` 실행을 시도했으나 실행환경에 `flutter` 명령이 없어 테스트를 수행하지 못했습니다 (미실행).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a02cafcd3f083278f160ede346e659d)