### PR TITLE
Cash detail redesign + full records screen and ERD mock helpers

### DIFF
--- a/lib/data/mock_erd_repository.dart
+++ b/lib/data/mock_erd_repository.dart
@@ -114,16 +114,20 @@ class MockErdRepository {
 
   // TODO(backend): 백엔드 연동 후 아래 목 지불수단 데이터는 PaymentMethod API 응답으로 교체하고 삭제하세요.
   final List<PaymentMethod> _paymentMethods = const [
-    PaymentMethod(id: 1, memberId: 1, name: '체크카드'),
+    PaymentMethod(id: 1, memberId: 1, name: '세계카드'),
     PaymentMethod(id: 2, memberId: 1, name: '현금'),
+    PaymentMethod(id: 3, memberId: 1, name: '체크카드'),
   ];
 
   // TODO(backend): 백엔드 연동 후 아래 목 카테고리 데이터는 Category API 응답으로 교체하고 삭제하세요.
   final List<Category> _categories = const [
-    Category(id: 1, name: '월급', type: 'INCOME'),
+    Category(id: 1, name: '이달 총 수입', type: 'INCOME'),
     Category(id: 2, name: '식비', type: 'EXPENSE'),
-    Category(id: 3, name: '교통', type: 'EXPENSE'),
-    Category(id: 4, name: '공부', type: 'CARD'),
+    Category(id: 3, name: '교통비', type: 'EXPENSE'),
+    Category(id: 4, name: '쇼핑', type: 'EXPENSE'),
+    Category(id: 5, name: '문화생활', type: 'EXPENSE'),
+    Category(id: 6, name: '부수입', type: 'INCOME'),
+    Category(id: 7, name: '카페', type: 'EXPENSE'),
   ];
 
   // TODO(backend): 백엔드 연동 후 아래 목 일정 데이터는 Schedule CRUD API 응답으로 교체하고 삭제하세요.
@@ -138,7 +142,7 @@ class MockErdRepository {
     Schedule(
       id: 2,
       memberId: 1,
-      title: '친구 약속',
+      title: '클릭까스 태릉점',
       startTime: DateTime.now().copyWith(hour: 11, minute: 0, second: 0, millisecond: 0, microsecond: 0),
       endTime: DateTime.now().copyWith(hour: 15, minute: 30, second: 0, millisecond: 0, microsecond: 0),
     ),
@@ -166,7 +170,7 @@ class MockErdRepository {
       scheduleId: null,
       categoryId: 1,
       paymentMethodId: 1,
-      amount: 3200000,
+      amount: 280000,
       transactionTime: DateTime.now().copyWith(hour: 9, minute: 0, second: 0, millisecond: 0, microsecond: 0),
     ),
     AccountRecord(
@@ -175,7 +179,7 @@ class MockErdRepository {
       scheduleId: 2,
       categoryId: 2,
       paymentMethodId: 1,
-      amount: -12000,
+      amount: -12900,
       transactionTime: DateTime.now().copyWith(hour: 12, minute: 20, second: 0, millisecond: 0, microsecond: 0),
     ),
     AccountRecord(
@@ -183,9 +187,54 @@ class MockErdRepository {
       memberId: 1,
       scheduleId: null,
       categoryId: 3,
+      paymentMethodId: 1,
+      amount: -6900,
+      transactionTime: DateTime.now().copyWith(hour: 8, minute: 40, second: 0, millisecond: 0, microsecond: 0),
+    ),
+    AccountRecord(
+      id: 4,
+      memberId: 1,
+      scheduleId: null,
+      categoryId: 7,
+      paymentMethodId: 1,
+      amount: -6900,
+      transactionTime: DateTime.now().subtract(const Duration(days: 1)).copyWith(hour: 15, minute: 10, second: 0, millisecond: 0, microsecond: 0),
+    ),
+    AccountRecord(
+      id: 5,
+      memberId: 1,
+      scheduleId: null,
+      categoryId: 4,
+      paymentMethodId: 3,
+      amount: -84000,
+      transactionTime: DateTime.now().subtract(const Duration(days: 2)).copyWith(hour: 19, minute: 30, second: 0, millisecond: 0, microsecond: 0),
+    ),
+    AccountRecord(
+      id: 6,
+      memberId: 1,
+      scheduleId: null,
+      categoryId: 5,
       paymentMethodId: 2,
-      amount: -3500,
-      transactionTime: DateTime.now().copyWith(hour: 18, minute: 10, second: 0, millisecond: 0, microsecond: 0),
+      amount: -42000,
+      transactionTime: DateTime.now().subtract(const Duration(days: 3)).copyWith(hour: 20, minute: 0, second: 0, millisecond: 0, microsecond: 0),
+    ),
+    AccountRecord(
+      id: 7,
+      memberId: 1,
+      scheduleId: null,
+      categoryId: 6,
+      paymentMethodId: 2,
+      amount: 120000,
+      transactionTime: DateTime.now().subtract(const Duration(days: 5)).copyWith(hour: 18, minute: 0, second: 0, millisecond: 0, microsecond: 0),
+    ),
+    AccountRecord(
+      id: 8,
+      memberId: 1,
+      scheduleId: null,
+      categoryId: 2,
+      paymentMethodId: 1,
+      amount: -18500,
+      transactionTime: DateTime.now().subtract(const Duration(days: 8)).copyWith(hour: 13, minute: 5, second: 0, millisecond: 0, microsecond: 0),
     ),
   ];
 
@@ -225,6 +274,41 @@ class MockErdRepository {
         .where((record) => record.memberId == targetMemberId)
         .map(_toAccountRecordView)
         .toList(growable: false);
+  }
+
+  /// 소비 상세/전체보기에서 최근 거래 순서로 사용할 수입·지출 조인 목록입니다.
+  List<AccountRecordView> sortedAccountRecordViews({int? memberId}) {
+    final records = allAccountRecordViews(memberId: memberId);
+    records.sort((left, right) => right.record.transactionTime.compareTo(left.record.transactionTime));
+    return records;
+  }
+
+  /// ERD Category.type 값으로 수입/지출을 구분해 월별 거래를 필터링합니다.
+  List<AccountRecordView> accountRecordsByMonth(DateTime month, {String? type, int? memberId}) {
+    return sortedAccountRecordViews(memberId: memberId)
+        .where((view) =>
+            view.record.transactionTime.year == month.year &&
+            view.record.transactionTime.month == month.month &&
+            (type == null || view.category.type == type))
+        .toList(growable: false);
+  }
+
+  /// 상단 요약 카드에서 사용하는 오늘 수입/지출 합계를 계산합니다.
+  int todayTotalByType(String type, {int? memberId}) {
+    final now = DateTime.now();
+    final today = DateTime(now.year, now.month, now.day);
+    return accountRecordsByDate(today, memberId: memberId)
+        .where((view) => view.category.type == type)
+        .fold(0, (sum, view) => sum + view.record.amount.abs());
+  }
+
+  /// 카테고리별 지출 막대 차트에 사용할 월간 지출 합계를 계산합니다.
+  Map<Category, int> monthlyExpenseTotalsByCategory(DateTime month, {int? memberId}) {
+    final totals = <Category, int>{};
+    for (final view in accountRecordsByMonth(month, type: 'EXPENSE', memberId: memberId)) {
+      totals.update(view.category, (value) => value + view.record.amount.abs(), ifAbsent: () => view.record.amount.abs());
+    }
+    return totals;
   }
 
   AccountRecordView _toAccountRecordView(AccountRecord record) {

--- a/lib/routes/app_router.dart
+++ b/lib/routes/app_router.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import '../screen/auth/login_screen.dart';
 import '../screen/auth/sighup_screen.dart';
 import '../screen/cash/cash_detail__screen.dart';
+import '../screen/cash/cash_records_screen.dart';
 import '../screen/day/day_detail__screen.dart';
 import '../screen/day/my_expense_category_screen.dart';
 import '../screen/day/my_faq_screen.dart';
@@ -41,6 +42,11 @@ class AppRouter {
       case Routes.cashDetail:
         return MaterialPageRoute(
           builder: (_) => CashDetailScreen(loginEmail: loginEmail),
+          settings: settings,
+        );
+      case Routes.cashRecords:
+        return MaterialPageRoute(
+          builder: (_) => CashRecordsScreen(loginEmail: loginEmail),
           settings: settings,
         );
       case Routes.mypage:

--- a/lib/routes/routes.dart
+++ b/lib/routes/routes.dart
@@ -5,6 +5,7 @@ class Routes {
   static const main = '/main';
   static const dayDetail = '/day-detail';
   static const cashDetail = '/cash-detail';
+  static const cashRecords = '/cash-records';
   static const mypage = '/mypage';
 
   // ✅ 마이페이지 각 메뉴 전용 라우트

--- a/lib/screen/cash/cash_detail__screen.dart
+++ b/lib/screen/cash/cash_detail__screen.dart
@@ -1,85 +1,360 @@
 import 'package:flutter/material.dart';
 
 import '../../data/mock_erd_repository.dart';
-import '../../widgets/template/base_scaffold.dart';
+import '../../routes/routes.dart';
 import '../../widgets/template/bottom_nav_layout.dart';
 
+/// 소비 상세 페이지입니다. ERD의 AccountRecord/Category/PaymentMethod 관계를 목데이터로 시각화합니다.
 class CashDetailScreen extends StatelessWidget {
   final String loginEmail;
 
   const CashDetailScreen({super.key, this.loginEmail = ''});
 
+  static const _primaryPink = Color(0xFFF7A5A5);
+  static const _lineNavy = Color(0xFF53627D);
+  static const _green = Color(0xFF4CC83D);
+  static const _red = Color(0xFFFF4D55);
+  static const _blue = Color(0xFF5E77FF);
+  static const _purple = Color(0xFFB868FF);
+
   @override
   Widget build(BuildContext context) {
-    final records = MockErdRepository.instance.allAccountRecordViews();
+    final repository = MockErdRepository.instance;
+    final now = DateTime.now();
+    final recentRecords = repository.sortedAccountRecordViews().take(4).toList(growable: false);
+    final expenseTotals = repository.monthlyExpenseTotalsByCategory(now);
+    final todayIncome = repository.todayTotalByType('INCOME');
+    final todayExpense = repository.todayTotalByType('EXPENSE');
 
-    return BaseScaffold(
-      title: 'Cash Detail',
-      body: Column(
-        children: [
-          Expanded(
-            child: ListView(
-              padding: const EdgeInsets.all(20),
-              children: [
-                const Text('수입/지출 내역', style: TextStyle(fontSize: 18, fontWeight: FontWeight.w700)),
-                const SizedBox(height: 12),
-                // ✅ ERD의 AccountRecord와 Category/PaymentMethod/Schedule 조인 결과를 목데이터로 표시합니다.
-                ...records.map((record) => _CashRecordCard(record: record)),
-              ],
+    return Scaffold(
+      backgroundColor: Colors.white,
+      body: SafeArea(
+        child: Column(
+          children: [
+            Expanded(
+              child: ListView(
+                padding: const EdgeInsets.fromLTRB(16, 14, 16, 18),
+                children: [
+                  const Center(
+                    child: Text(
+                      '소비 상세 페이지',
+                      style: TextStyle(color: _lineNavy, fontSize: 15, fontWeight: FontWeight.w800),
+                    ),
+                  ),
+                  const SizedBox(height: 28),
+                  Row(
+                    children: [
+                      Expanded(
+                        child: _TopActionButton(
+                          label: '+ 지출 추가',
+                          backgroundColor: _primaryPink,
+                          textColor: Colors.white,
+                          onTap: () {},
+                        ),
+                      ),
+                      const SizedBox(width: 18),
+                      Expanded(
+                        child: _TopActionButton(
+                          label: '전체 보기',
+                          backgroundColor: Colors.white,
+                          textColor: _lineNavy,
+                          onTap: () => _openAllRecords(context),
+                        ),
+                      ),
+                    ],
+                  ),
+                  const SizedBox(height: 18),
+                  Row(
+                    children: [
+                      Expanded(
+                        child: _TodaySummaryCard(
+                          title: '오늘 총 수입',
+                          amount: todayIncome,
+                          rateText: '+12.5%',
+                          accentColor: _green,
+                          chartIcon: Icons.show_chart,
+                        ),
+                      ),
+                      const SizedBox(width: 18),
+                      Expanded(
+                        child: _TodaySummaryCard(
+                          title: '오늘 총 지출',
+                          amount: todayExpense,
+                          rateText: '-8.2%',
+                          accentColor: _red,
+                          chartIcon: Icons.trending_down,
+                        ),
+                      ),
+                    ],
+                  ),
+                  const SizedBox(height: 18),
+                  _OutlinedSection(
+                    child: _CategoryExpenseChart(
+                      totals: expenseTotals,
+                      colors: const [_blue, _green, _red, _purple],
+                    ),
+                  ),
+                  const SizedBox(height: 18),
+                  _OutlinedSection(
+                    height: 310,
+                    child: _RecentRecords(
+                      records: recentRecords,
+                      onViewAll: () => _openAllRecords(context),
+                    ),
+                  ),
+                ],
+              ),
             ),
+            BottomNavLayout(loginEmail: loginEmail, currentTab: BottomNavType.cash),
+          ],
+        ),
+      ),
+    );
+  }
+
+  /// 최근 거래 섹션과 상단 전체 보기 버튼이 같은 전체 거래 페이지로 이동합니다.
+  void _openAllRecords(BuildContext context) {
+    Navigator.of(context).pushNamed(Routes.cashRecords, arguments: {'loginEmail': loginEmail});
+  }
+}
+
+class _TopActionButton extends StatelessWidget {
+  final String label;
+  final Color backgroundColor;
+  final Color textColor;
+  final VoidCallback onTap;
+
+  const _TopActionButton({
+    required this.label,
+    required this.backgroundColor,
+    required this.textColor,
+    required this.onTap,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return InkWell(
+      borderRadius: BorderRadius.circular(6),
+      onTap: onTap,
+      child: Container(
+        height: 44,
+        alignment: Alignment.center,
+        decoration: BoxDecoration(
+          color: backgroundColor,
+          border: Border.all(color: CashDetailScreen._lineNavy, width: 1),
+          borderRadius: BorderRadius.circular(6),
+        ),
+        child: Text(label, style: TextStyle(color: textColor, fontSize: 13, fontWeight: FontWeight.w700)),
+      ),
+    );
+  }
+}
+
+class _TodaySummaryCard extends StatelessWidget {
+  final String title;
+  final int amount;
+  final String rateText;
+  final Color accentColor;
+  final IconData chartIcon;
+
+  const _TodaySummaryCard({
+    required this.title,
+    required this.amount,
+    required this.rateText,
+    required this.accentColor,
+    required this.chartIcon,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      height: 94,
+      padding: const EdgeInsets.all(12),
+      decoration: BoxDecoration(
+        color: Colors.white,
+        border: Border.all(color: CashDetailScreen._lineNavy, width: 1),
+        borderRadius: BorderRadius.circular(6),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            children: [
+              Icon(chartIcon, size: 18, color: accentColor),
+              Text(rateText, style: TextStyle(color: accentColor, fontSize: 10, fontWeight: FontWeight.w700)),
+            ],
           ),
-          // ✅ 모든 화면에서 하단 탭을 공통으로 유지
-          BottomNavLayout(loginEmail: loginEmail, currentTab: BottomNavType.cash),
+          const Spacer(),
+          Text(title, style: const TextStyle(color: CashDetailScreen._lineNavy, fontSize: 11, fontWeight: FontWeight.w700)),
+          const SizedBox(height: 4),
+          Text(_formatWon(amount), style: const TextStyle(color: CashDetailScreen._lineNavy, fontSize: 14, fontWeight: FontWeight.w800)),
         ],
       ),
     );
   }
 }
 
-class _CashRecordCard extends StatelessWidget {
+class _OutlinedSection extends StatelessWidget {
+  final Widget child;
+  final double? height;
+
+  const _OutlinedSection({required this.child, this.height});
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      height: height,
+      width: double.infinity,
+      padding: const EdgeInsets.all(16),
+      decoration: BoxDecoration(
+        color: Colors.white,
+        border: Border.all(color: CashDetailScreen._lineNavy, width: 1),
+        borderRadius: BorderRadius.circular(6),
+      ),
+      child: child,
+    );
+  }
+}
+
+class _CategoryExpenseChart extends StatelessWidget {
+  final Map<Category, int> totals;
+  final List<Color> colors;
+
+  const _CategoryExpenseChart({required this.totals, required this.colors});
+
+  @override
+  Widget build(BuildContext context) {
+    final entries = totals.entries.toList(growable: false);
+    final maxTotal = entries.fold<int>(1, (max, entry) => entry.value > max ? entry.value : max);
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        const Row(
+          children: [
+            Icon(Icons.credit_card, size: 16, color: CashDetailScreen._lineNavy),
+            SizedBox(width: 6),
+            Text('카테고리별 지출', style: TextStyle(color: CashDetailScreen._lineNavy, fontSize: 12, fontWeight: FontWeight.w800)),
+          ],
+        ),
+        const SizedBox(height: 26),
+        if (entries.isEmpty)
+          const Center(child: Text('이번 달 지출 내역이 없어요.', style: TextStyle(color: Colors.black45, fontSize: 12)))
+        else
+          ...entries.asMap().entries.map((indexed) {
+            final color = colors[indexed.key % colors.length];
+            final category = indexed.value.key;
+            final amount = indexed.value.value;
+            final ratio = amount / maxTotal;
+            return Padding(
+              padding: const EdgeInsets.only(bottom: 20),
+              child: _ExpenseBar(categoryName: category.name, amount: amount, ratio: ratio, color: color),
+            );
+          }),
+      ],
+    );
+  }
+}
+
+class _ExpenseBar extends StatelessWidget {
+  final String categoryName;
+  final int amount;
+  final double ratio;
+  final Color color;
+
+  const _ExpenseBar({required this.categoryName, required this.amount, required this.ratio, required this.color});
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Row(
+          children: [
+            Icon(Icons.circle, color: color, size: 8),
+            const SizedBox(width: 4),
+            Text(categoryName, style: const TextStyle(color: CashDetailScreen._lineNavy, fontSize: 11, fontWeight: FontWeight.w800)),
+          ],
+        ),
+        const SizedBox(height: 4),
+        Stack(
+          children: [
+            Container(height: 6, decoration: BoxDecoration(color: const Color(0xFFE6E6E6), borderRadius: BorderRadius.circular(8))),
+            FractionallySizedBox(
+              widthFactor: ratio.clamp(0.08, 1.0).toDouble(),
+              child: Container(height: 6, decoration: BoxDecoration(color: color, borderRadius: BorderRadius.circular(8))),
+            ),
+          ],
+        ),
+        const SizedBox(height: 3),
+        Row(
+          mainAxisAlignment: MainAxisAlignment.spaceBetween,
+          children: [
+            Text(_formatWon(amount), style: const TextStyle(color: CashDetailScreen._lineNavy, fontSize: 9)),
+            const Text('₩', style: TextStyle(color: CashDetailScreen._lineNavy, fontSize: 10)),
+          ],
+        ),
+      ],
+    );
+  }
+}
+
+class _RecentRecords extends StatelessWidget {
+  final List<AccountRecordView> records;
+  final VoidCallback onViewAll;
+
+  const _RecentRecords({required this.records, required this.onViewAll});
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Row(
+          mainAxisAlignment: MainAxisAlignment.spaceBetween,
+          children: [
+            const Text('최근 거래', style: TextStyle(color: CashDetailScreen._lineNavy, fontSize: 12, fontWeight: FontWeight.w800)),
+            InkWell(onTap: onViewAll, child: const Text('전체 보기', style: TextStyle(color: CashDetailScreen._lineNavy, fontSize: 10))),
+          ],
+        ),
+        const SizedBox(height: 12),
+        if (records.isEmpty)
+          const Expanded(child: Center(child: Text('최근 거래가 없어요.', style: TextStyle(color: Colors.black45, fontSize: 12))))
+        else
+          ...records.map((record) => _RecentRecordTile(record: record)),
+      ],
+    );
+  }
+}
+
+class _RecentRecordTile extends StatelessWidget {
   final AccountRecordView record;
 
-  const _CashRecordCard({required this.record});
+  const _RecentRecordTile({required this.record});
 
   @override
   Widget build(BuildContext context) {
     final amount = record.record.amount;
-    final amountText = amount >= 0 ? '+$amount' : '$amount';
-
-    return Container(
-      margin: const EdgeInsets.only(bottom: 10),
-      padding: const EdgeInsets.all(14),
-      decoration: BoxDecoration(
-        color: Colors.white,
-        borderRadius: BorderRadius.circular(16),
-        boxShadow: [
-          BoxShadow(color: Colors.black.withValues(alpha: 0.05), blurRadius: 10, offset: const Offset(0, 4)),
-        ],
-      ),
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 12),
       child: Row(
-        mainAxisAlignment: MainAxisAlignment.spaceBetween,
         children: [
-          Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              Text(record.category.name, style: const TextStyle(fontWeight: FontWeight.w700)),
-              const SizedBox(height: 4),
-              Text(
-                '${record.paymentMethod.name} · ${_formatDateTime(record.record.transactionTime)}',
-                style: const TextStyle(fontSize: 12, color: Colors.black54),
-              ),
-              if (record.schedule != null) ...[
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(_recordTitle(record), style: const TextStyle(color: CashDetailScreen._lineNavy, fontSize: 12, fontWeight: FontWeight.w700)),
                 const SizedBox(height: 4),
-                Text('연결 일정: ${record.schedule!.title}', style: const TextStyle(fontSize: 12, color: Colors.black45)),
+                Text(record.category.name, style: const TextStyle(color: Colors.black38, fontSize: 10)),
               ],
-            ],
-          ),
-          Text(
-            amountText,
-            style: TextStyle(
-              color: amount >= 0 ? const Color(0xFF1B5E20) : const Color(0xFFB71C1C),
-              fontWeight: FontWeight.w700,
             ),
+          ),
+          Text(record.paymentMethod.name, style: const TextStyle(color: CashDetailScreen._lineNavy, fontSize: 10)),
+          const SizedBox(width: 8),
+          Text(
+            _formatSignedAmount(amount),
+            style: TextStyle(color: amount >= 0 ? const Color(0xFF1B5E20) : Colors.red, fontSize: 11, fontWeight: FontWeight.w800),
           ),
         ],
       ),
@@ -87,5 +362,18 @@ class _CashRecordCard extends StatelessWidget {
   }
 }
 
-String _formatDateTime(DateTime time) =>
-    '${time.month}/${time.day} ${time.hour.toString().padLeft(2, '0')}:${time.minute.toString().padLeft(2, '0')}';
+String _recordTitle(AccountRecordView record) => record.schedule?.title ?? record.category.name;
+
+String _formatSignedAmount(int amount) => '${amount < 0 ? '-' : '+'}${_formatNumber(amount.abs())}';
+
+String _formatWon(int amount) => '₩${_formatNumber(amount)}';
+
+String _formatNumber(int value) {
+  final text = value.toString();
+  final buffer = StringBuffer();
+  for (var i = 0; i < text.length; i++) {
+    if (i != 0 && (text.length - i) % 3 == 0) buffer.write(',');
+    buffer.write(text[i]);
+  }
+  return buffer.toString();
+}

--- a/lib/screen/cash/cash_records_screen.dart
+++ b/lib/screen/cash/cash_records_screen.dart
@@ -1,0 +1,274 @@
+import 'package:flutter/material.dart';
+
+import '../../data/mock_erd_repository.dart';
+import '../../widgets/template/bottom_nav_layout.dart';
+
+/// 최근 거래의 전체 보기 화면입니다. 월/수입·지출 필터는 ERD Category.type과 transactionTime을 기준으로 동작합니다.
+class CashRecordsScreen extends StatefulWidget {
+  final String loginEmail;
+
+  const CashRecordsScreen({super.key, this.loginEmail = ''});
+
+  @override
+  State<CashRecordsScreen> createState() => _CashRecordsScreenState();
+}
+
+class _CashRecordsScreenState extends State<CashRecordsScreen> {
+  static const _primaryPink = Color(0xFFFFA4A9);
+  static const _softPink = Color(0xFFFFF1EF);
+  static const _lineNavy = Color(0xFF53627D);
+
+  final MockErdRepository _repository = MockErdRepository.instance;
+  late DateTime _visibleMonth;
+  _RecordFilter _filter = _RecordFilter.expense;
+
+  @override
+  void initState() {
+    super.initState();
+    final now = DateTime.now();
+    // ✅ 전체보기 진입 시 현재 월부터 보여주고 좌우 버튼으로 월을 이동합니다.
+    _visibleMonth = DateTime(now.year, now.month);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final records = _repository.accountRecordsByMonth(_visibleMonth, type: _filter.type);
+    final grouped = _groupRecordsByCategory(records);
+
+    return Scaffold(
+      backgroundColor: Colors.white,
+      body: SafeArea(
+        child: Column(
+          children: [
+            _Header(onBack: () => Navigator.of(context).pop()),
+            Expanded(
+              child: ListView(
+                padding: const EdgeInsets.fromLTRB(14, 12, 14, 18),
+                children: [
+                  _MonthSelector(
+                    month: _visibleMonth,
+                    onPrevious: () => _changeMonth(-1),
+                    onNext: () => _changeMonth(1),
+                  ),
+                  const SizedBox(height: 10),
+                  _FilterTabs(
+                    selectedFilter: _filter,
+                    onChanged: (filter) => setState(() => _filter = filter),
+                  ),
+                  const SizedBox(height: 14),
+                  if (grouped.isEmpty)
+                    const Padding(
+                      padding: EdgeInsets.only(top: 80),
+                      child: Center(child: Text('해당 월의 거래 내역이 없어요.', style: TextStyle(color: Colors.black45, fontSize: 12))),
+                    )
+                  else
+                    ...grouped.entries.map(
+                      (entry) => _CategoryGroup(categoryName: entry.key, records: entry.value),
+                    ),
+                ],
+              ),
+            ),
+            BottomNavLayout(loginEmail: widget.loginEmail, currentTab: BottomNavType.cash),
+          ],
+        ),
+      ),
+    );
+  }
+
+  void _changeMonth(int delta) {
+    setState(() => _visibleMonth = DateTime(_visibleMonth.year, _visibleMonth.month + delta));
+  }
+
+  /// 전체 거래 목록은 이미지 시안처럼 카테고리 제목 아래 거래가 모이도록 그룹핑합니다.
+  Map<String, List<AccountRecordView>> _groupRecordsByCategory(List<AccountRecordView> records) {
+    final grouped = <String, List<AccountRecordView>>{};
+    for (final record in records) {
+      grouped.putIfAbsent(record.category.name, () => []).add(record);
+    }
+    return grouped;
+  }
+}
+
+enum _RecordFilter {
+  expense('지출', 'EXPENSE'),
+  income('수입', 'INCOME');
+
+  final String label;
+  final String type;
+
+  const _RecordFilter(this.label, this.type);
+}
+
+class _Header extends StatelessWidget {
+  final VoidCallback onBack;
+
+  const _Header({required this.onBack});
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      height: 44,
+      color: _CashRecordsScreenState._softPink,
+      child: Stack(
+        alignment: Alignment.center,
+        children: [
+          Align(
+            alignment: Alignment.centerLeft,
+            child: IconButton(
+              icon: const Icon(Icons.chevron_left, color: _CashRecordsScreenState._primaryPink),
+              onPressed: onBack,
+            ),
+          ),
+          const Text('전체 보기', style: TextStyle(color: _CashRecordsScreenState._lineNavy, fontSize: 14, fontWeight: FontWeight.w800)),
+        ],
+      ),
+    );
+  }
+}
+
+class _MonthSelector extends StatelessWidget {
+  final DateTime month;
+  final VoidCallback onPrevious;
+  final VoidCallback onNext;
+
+  const _MonthSelector({required this.month, required this.onPrevious, required this.onNext});
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      children: [
+        InkWell(onTap: onPrevious, child: const Icon(Icons.chevron_left, size: 20, color: Colors.black87)),
+        const SizedBox(width: 12),
+        Text('${month.month}월', style: const TextStyle(fontSize: 13, color: Colors.black87, fontWeight: FontWeight.w700)),
+        const SizedBox(width: 12),
+        InkWell(onTap: onNext, child: const Icon(Icons.chevron_right, size: 20, color: Colors.black87)),
+      ],
+    );
+  }
+}
+
+class _FilterTabs extends StatelessWidget {
+  final _RecordFilter selectedFilter;
+  final ValueChanged<_RecordFilter> onChanged;
+
+  const _FilterTabs({required this.selectedFilter, required this.onChanged});
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      children: _RecordFilter.values.map((filter) {
+        final isSelected = selectedFilter == filter;
+        return InkWell(
+          onTap: () => onChanged(filter),
+          child: Container(
+            width: 54,
+            padding: const EdgeInsets.symmetric(vertical: 8),
+            alignment: Alignment.center,
+            decoration: BoxDecoration(
+              border: Border(bottom: BorderSide(color: isSelected ? _CashRecordsScreenState._lineNavy : Colors.black12, width: 1)),
+            ),
+            child: Text(
+              filter.label,
+              style: TextStyle(
+                color: isSelected ? _CashRecordsScreenState._lineNavy : Colors.black45,
+                fontSize: 13,
+                fontWeight: isSelected ? FontWeight.w800 : FontWeight.w500,
+              ),
+            ),
+          ),
+        );
+      }).toList(growable: false),
+    );
+  }
+}
+
+class _CategoryGroup extends StatelessWidget {
+  final String categoryName;
+  final List<AccountRecordView> records;
+
+  const _CategoryGroup({required this.categoryName, required this.records});
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 72),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            children: [
+              const Icon(Icons.local_dining, size: 14, color: Colors.black),
+              const SizedBox(width: 4),
+              Text(categoryName, style: const TextStyle(color: Colors.black, fontSize: 12, fontWeight: FontWeight.w800)),
+            ],
+          ),
+          const SizedBox(height: 10),
+          const Divider(height: 1, color: Color(0xFFE2E2E2)),
+          const SizedBox(height: 10),
+          ...records.map((record) => _RecordRow(record: record)),
+        ],
+      ),
+    );
+  }
+}
+
+class _RecordRow extends StatelessWidget {
+  final AccountRecordView record;
+
+  const _RecordRow({required this.record});
+
+  @override
+  Widget build(BuildContext context) {
+    final amount = record.record.amount;
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 14),
+      child: Row(
+        children: [
+          Expanded(
+            child: Text(
+              _recordTitle(record),
+              style: const TextStyle(color: _CashRecordsScreenState._lineNavy, fontSize: 12, fontWeight: FontWeight.w600),
+            ),
+          ),
+          Text(record.paymentMethod.name, style: const TextStyle(color: _CashRecordsScreenState._lineNavy, fontSize: 10)),
+          const SizedBox(width: 4),
+          const Icon(Icons.credit_card, size: 13, color: _CashRecordsScreenState._lineNavy),
+          const SizedBox(width: 8),
+          Text(
+            _formatSignedAmount(amount),
+            style: TextStyle(color: amount >= 0 ? const Color(0xFF1B5E20) : Colors.red, fontSize: 12, fontWeight: FontWeight.w800),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+String _recordTitle(AccountRecordView record) => record.schedule?.title ?? _fallbackTitle(record);
+
+String _fallbackTitle(AccountRecordView record) {
+  switch (record.category.name) {
+    case '카페':
+      return '스타벅스 노원역';
+    case '교통비':
+      return '역전우동';
+    case '쇼핑':
+      return '온라인 쇼핑';
+    case '문화생활':
+      return '영화 예매';
+    default:
+      return record.category.name;
+  }
+}
+
+String _formatSignedAmount(int amount) => '${amount < 0 ? '-' : '+'}${_formatNumber(amount.abs())}';
+
+String _formatNumber(int value) {
+  final text = value.toString();
+  final buffer = StringBuffer();
+  for (var i = 0; i < text.length; i++) {
+    if (i != 0 && (text.length - i) % 3 == 0) buffer.write(',');
+    buffer.write(text[i]);
+  }
+  return buffer.toString();
+}


### PR DESCRIPTION
### Motivation
- Implement a 시안-based 소비 상세 페이지 that shows summary cards, category expense bars and a recent-transactions area with a pathway to view all records. 
- Provide a full “전체 보기” page for recent transactions and enrich the in-memory ERD-aligned mock repository to support sorting, monthly filtering and summary totals. 
- 요약: 소비 상세화면 재구성 및 전체 거래 페이지 추가, ERD 목데이터와 헬퍼를 확장하여 화면에서 바로 사용할 수 있게 했습니다.

### Description
- Rebuilt `CashDetailScreen` UI to include top action buttons, today income/expense summary cards, category expense bars and a recent transactions list (file: `lib/screen/cash/cash_detail__screen.dart`).
- Added a new full-view screen `CashRecordsScreen` with month navigation and 수입/지출 필터ing and grouped-by-category lists (file: `lib/screen/cash/cash_records_screen.dart`).
- Extended `MockErdRepository` with additional mock categories/payment methods/records and helpers: `sortedAccountRecordViews`, `accountRecordsByMonth`, `todayTotalByType`, and `monthlyExpenseTotalsByCategory` (file: `lib/data/mock_erd_repository.dart`).
- Registered a new route `Routes.cashRecords` and wired it into the app router so the recent-section and top “전체 보기” button navigate to the new screen (files: `lib/routes/routes.dart`, `lib/routes/app_router.dart`).

### Testing
- `git diff --check` passed with no whitespace/error issues.
- Attempts to run `dart format` and `flutter analyze` were made but could not run because the environment does not have `dart`/`flutter` installed, so static analysis/format checks were not executed here.
- `flutter test` was not executed for the same reason (`flutter` not available in the environment).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a02db7d43388327b3d40d054aa9c876)