### PR TITLE
Use member id consistently in mock data

### DIFF
--- a/lib/data/mock_erd_repository.dart
+++ b/lib/data/mock_erd_repository.dart
@@ -14,33 +14,37 @@ class Member {
 
 /// 지불수단(PaymentMethod) 테이블 모델입니다.
 class PaymentMethod {
+  /// 로그인/가입 후 발급되는 회원 고유번호입니다.
   final int id;
-  final int memberId;
+  final int paymentMethodId;
   final String name;
 
-  const PaymentMethod({required this.id, required this.memberId, required this.name});
+  const PaymentMethod({required this.id, required this.paymentMethodId, required this.name});
 }
 
 /// 카테고리(Category) 테이블 모델입니다.
 class Category {
+  /// 로그인/가입 후 발급되는 회원 고유번호입니다.
   final int id;
+  final int categoryId;
   final String name;
   final String type;
 
-  const Category({required this.id, required this.name, required this.type});
+  const Category({required this.id, required this.categoryId, required this.name, required this.type});
 }
 
 /// 일정(Schedule) 테이블 모델입니다.
 class Schedule {
+  /// 로그인/가입 후 발급되는 회원 고유번호입니다.
   final int id;
-  final int memberId;
+  final int scheduleId;
   final String title;
   final DateTime startTime;
   final DateTime endTime;
 
   const Schedule({
     required this.id,
-    required this.memberId,
+    required this.scheduleId,
     required this.title,
     required this.startTime,
     required this.endTime,
@@ -49,18 +53,27 @@ class Schedule {
 
 /// 할일(Task) 테이블 모델입니다.
 class Task {
+  /// 로그인/가입 후 발급되는 회원 고유번호입니다.
   final int id;
+  final int taskId;
   final int scheduleId;
   final String content;
   final bool isCompleted;
 
-  const Task({required this.id, required this.scheduleId, required this.content, required this.isCompleted});
+  const Task({
+    required this.id,
+    required this.taskId,
+    required this.scheduleId,
+    required this.content,
+    required this.isCompleted,
+  });
 }
 
 /// 수입/지출내역(AccountRecord) 테이블 모델입니다.
 class AccountRecord {
+  /// 로그인/가입 후 발급되는 회원 고유번호입니다.
   final int id;
-  final int memberId;
+  final int accountRecordId;
   final int? scheduleId;
   final int categoryId;
   final int paymentMethodId;
@@ -69,7 +82,7 @@ class AccountRecord {
 
   const AccountRecord({
     required this.id,
-    required this.memberId,
+    required this.accountRecordId,
     required this.scheduleId,
     required this.categoryId,
     required this.paymentMethodId,
@@ -108,65 +121,81 @@ class MockErdRepository {
   static final MockErdRepository instance = MockErdRepository._();
 
   // TODO(backend): 백엔드 연동 후 아래 목 회원 데이터는 실제 로그인 사용자 응답으로 교체하고 삭제하세요.
-  final List<Member> _members = const [
-    Member(id: 1, email: 'segye@example.com', password: 'mock-password'),
+  final List<Member> _members = [
+    const Member(id: 1, email: 'segye@example.com', password: 'mock-password'),
+    const Member(id: 2, email: 'hana@example.com', password: 'mock-password'),
   ];
 
+  // 화면별 조회가 로그인 회원 기준으로 동작하도록 현재 선택된 회원 고유번호(id)를 보관합니다.
+  int _currentId = 1;
+
   // TODO(backend): 백엔드 연동 후 아래 목 지불수단 데이터는 PaymentMethod API 응답으로 교체하고 삭제하세요.
-  final List<PaymentMethod> _paymentMethods = const [
-    PaymentMethod(id: 1, memberId: 1, name: '세계카드'),
-    PaymentMethod(id: 2, memberId: 1, name: '현금'),
-    PaymentMethod(id: 3, memberId: 1, name: '체크카드'),
+  final List<PaymentMethod> _paymentMethods = [
+    const PaymentMethod(id: 1, paymentMethodId: 1, name: '세계카드'),
+    const PaymentMethod(id: 1, paymentMethodId: 2, name: '현금'),
+    const PaymentMethod(id: 1, paymentMethodId: 3, name: '체크카드'),
+    const PaymentMethod(id: 2, paymentMethodId: 4, name: '하나카드'),
+    const PaymentMethod(id: 2, paymentMethodId: 5, name: '하나현금'),
   ];
 
   // TODO(backend): 백엔드 연동 후 아래 목 카테고리 데이터는 Category API 응답으로 교체하고 삭제하세요.
-  final List<Category> _categories = const [
-    Category(id: 1, name: '이달 총 수입', type: 'INCOME'),
-    Category(id: 2, name: '식비', type: 'EXPENSE'),
-    Category(id: 3, name: '교통비', type: 'EXPENSE'),
-    Category(id: 4, name: '쇼핑', type: 'EXPENSE'),
-    Category(id: 5, name: '문화생활', type: 'EXPENSE'),
-    Category(id: 6, name: '부수입', type: 'INCOME'),
-    Category(id: 7, name: '카페', type: 'EXPENSE'),
+  final List<Category> _categories = [
+    const Category(id: 1, categoryId: 1, name: '이달 총 수입', type: 'INCOME'),
+    const Category(id: 1, categoryId: 2, name: '식비', type: 'EXPENSE'),
+    const Category(id: 1, categoryId: 3, name: '교통비', type: 'EXPENSE'),
+    const Category(id: 1, categoryId: 4, name: '쇼핑', type: 'EXPENSE'),
+    const Category(id: 1, categoryId: 5, name: '문화생활', type: 'EXPENSE'),
+    const Category(id: 1, categoryId: 6, name: '부수입', type: 'INCOME'),
+    const Category(id: 1, categoryId: 7, name: '카페', type: 'EXPENSE'),
+    const Category(id: 2, categoryId: 8, name: '하나 월급', type: 'INCOME'),
+    const Category(id: 2, categoryId: 9, name: '하나 식비', type: 'EXPENSE'),
   ];
 
   // TODO(backend): 백엔드 연동 후 아래 목 일정 데이터는 Schedule CRUD API 응답으로 교체하고 삭제하세요.
   final List<Schedule> _schedules = [
     Schedule(
       id: 1,
-      memberId: 1,
+      scheduleId: 1,
       title: '아침 운동',
       startTime: DateTime.now().copyWith(hour: 7, minute: 0, second: 0, millisecond: 0, microsecond: 0),
       endTime: DateTime.now().copyWith(hour: 9, minute: 30, second: 0, millisecond: 0, microsecond: 0),
     ),
     Schedule(
-      id: 2,
-      memberId: 1,
+      id: 1,
+      scheduleId: 2,
       title: '클릭까스 태릉점',
       startTime: DateTime.now().copyWith(hour: 11, minute: 0, second: 0, millisecond: 0, microsecond: 0),
       endTime: DateTime.now().copyWith(hour: 15, minute: 30, second: 0, millisecond: 0, microsecond: 0),
     ),
     Schedule(
-      id: 3,
-      memberId: 1,
+      id: 1,
+      scheduleId: 3,
       title: '내일 회의 준비',
       startTime: DateTime.now().add(const Duration(days: 1)).copyWith(hour: 10, minute: 0, second: 0, millisecond: 0, microsecond: 0),
       endTime: DateTime.now().add(const Duration(days: 1)).copyWith(hour: 11, minute: 0, second: 0, millisecond: 0, microsecond: 0),
+    ),
+    Schedule(
+      id: 2,
+      scheduleId: 4,
+      title: '하나 독서 모임',
+      startTime: DateTime.now().copyWith(hour: 18, minute: 0, second: 0, millisecond: 0, microsecond: 0),
+      endTime: DateTime.now().copyWith(hour: 19, minute: 30, second: 0, millisecond: 0, microsecond: 0),
     ),
   ];
 
   // TODO(backend): 백엔드 연동 후 아래 목 할일 데이터는 Task CRUD API 응답으로 교체하고 삭제하세요.
   final List<Task> _tasks = const [
-    Task(id: 1, scheduleId: 1, content: '백준 알고리즘 실버 2문제', isCompleted: false),
-    Task(id: 2, scheduleId: 1, content: '두잉코딩 영어 1일차', isCompleted: true),
-    Task(id: 3, scheduleId: 3, content: '회의 자료 초안 작성', isCompleted: false),
+    Task(id: 1, taskId: 1, scheduleId: 1, content: '백준 알고리즘 실버 2문제', isCompleted: false),
+    Task(id: 1, taskId: 2, scheduleId: 1, content: '두잉코딩 영어 1일차', isCompleted: true),
+    Task(id: 1, taskId: 3, scheduleId: 3, content: '회의 자료 초안 작성', isCompleted: false),
+    Task(id: 2, taskId: 4, scheduleId: 4, content: '책 챕터 정리', isCompleted: false),
   ];
 
   // TODO(backend): 백엔드 연동 후 아래 목 수입/지출 데이터는 AccountRecord CRUD API 응답으로 교체하고 삭제하세요.
   final List<AccountRecord> _accountRecords = [
     AccountRecord(
       id: 1,
-      memberId: 1,
+      accountRecordId: 1,
       scheduleId: null,
       categoryId: 1,
       paymentMethodId: 1,
@@ -174,8 +203,8 @@ class MockErdRepository {
       transactionTime: DateTime.now().copyWith(hour: 9, minute: 0, second: 0, millisecond: 0, microsecond: 0),
     ),
     AccountRecord(
-      id: 2,
-      memberId: 1,
+      id: 1,
+      accountRecordId: 2,
       scheduleId: 2,
       categoryId: 2,
       paymentMethodId: 1,
@@ -183,8 +212,8 @@ class MockErdRepository {
       transactionTime: DateTime.now().copyWith(hour: 12, minute: 20, second: 0, millisecond: 0, microsecond: 0),
     ),
     AccountRecord(
-      id: 3,
-      memberId: 1,
+      id: 1,
+      accountRecordId: 3,
       scheduleId: null,
       categoryId: 3,
       paymentMethodId: 1,
@@ -192,8 +221,8 @@ class MockErdRepository {
       transactionTime: DateTime.now().copyWith(hour: 8, minute: 40, second: 0, millisecond: 0, microsecond: 0),
     ),
     AccountRecord(
-      id: 4,
-      memberId: 1,
+      id: 1,
+      accountRecordId: 4,
       scheduleId: null,
       categoryId: 7,
       paymentMethodId: 1,
@@ -201,8 +230,8 @@ class MockErdRepository {
       transactionTime: DateTime.now().subtract(const Duration(days: 1)).copyWith(hour: 15, minute: 10, second: 0, millisecond: 0, microsecond: 0),
     ),
     AccountRecord(
-      id: 5,
-      memberId: 1,
+      id: 1,
+      accountRecordId: 5,
       scheduleId: null,
       categoryId: 4,
       paymentMethodId: 3,
@@ -210,8 +239,8 @@ class MockErdRepository {
       transactionTime: DateTime.now().subtract(const Duration(days: 2)).copyWith(hour: 19, minute: 30, second: 0, millisecond: 0, microsecond: 0),
     ),
     AccountRecord(
-      id: 6,
-      memberId: 1,
+      id: 1,
+      accountRecordId: 6,
       scheduleId: null,
       categoryId: 5,
       paymentMethodId: 2,
@@ -219,8 +248,8 @@ class MockErdRepository {
       transactionTime: DateTime.now().subtract(const Duration(days: 3)).copyWith(hour: 20, minute: 0, second: 0, millisecond: 0, microsecond: 0),
     ),
     AccountRecord(
-      id: 7,
-      memberId: 1,
+      id: 1,
+      accountRecordId: 7,
       scheduleId: null,
       categoryId: 6,
       paymentMethodId: 2,
@@ -228,64 +257,131 @@ class MockErdRepository {
       transactionTime: DateTime.now().subtract(const Duration(days: 5)).copyWith(hour: 18, minute: 0, second: 0, millisecond: 0, microsecond: 0),
     ),
     AccountRecord(
-      id: 8,
-      memberId: 1,
+      id: 1,
+      accountRecordId: 8,
       scheduleId: null,
       categoryId: 2,
       paymentMethodId: 1,
       amount: -18500,
       transactionTime: DateTime.now().subtract(const Duration(days: 8)).copyWith(hour: 13, minute: 5, second: 0, millisecond: 0, microsecond: 0),
     ),
+    AccountRecord(
+      id: 2,
+      accountRecordId: 9,
+      scheduleId: 4,
+      categoryId: 9,
+      paymentMethodId: 4,
+      amount: -24000,
+      transactionTime: DateTime.now().copyWith(hour: 18, minute: 10, second: 0, millisecond: 0, microsecond: 0),
+    ),
+    AccountRecord(
+      id: 2,
+      accountRecordId: 10,
+      scheduleId: null,
+      categoryId: 8,
+      paymentMethodId: 5,
+      amount: 320000,
+      transactionTime: DateTime.now().copyWith(hour: 10, minute: 0, second: 0, millisecond: 0, microsecond: 0),
+    ),
   ];
 
-  Member get currentMember => _members.first;
+  Member get currentMember => _members.firstWhere((member) => member.id == _currentId);
 
-  List<Category> get categories => List.unmodifiable(_categories);
+  // 현재 로그인 회원의 카테고리만 반환해 다른 회원의 설정 항목이 섞이지 않도록 합니다.
+  List<Category> get categories => categoriesById(_currentId);
 
-  List<PaymentMethod> paymentMethodsByMember(int memberId) =>
-      _paymentMethods.where((method) => method.memberId == memberId).toList(growable: false);
+  Member? findMemberByEmail(String email) {
+    final normalizedEmail = email.trim();
+    if (normalizedEmail.isEmpty) return null;
 
-  List<ScheduleWithTasks> schedulesByDate(DateTime date, {int? memberId}) {
-    final targetMemberId = memberId ?? currentMember.id;
+    for (final member in _members) {
+      if (member.email == normalizedEmail) return member;
+    }
+    return null;
+  }
+
+  Member? login(String email, String password) {
+    final normalizedEmail = email.trim();
+    final member = findMemberByEmail(normalizedEmail);
+
+    // 로그인은 아이디(이메일)와 비밀번호가 모두 맞을 때만 현재 회원 id를 변경합니다.
+    if (member == null || member.password != password) return null;
+
+    _currentId = member.id;
+    return member;
+  }
+
+  Member registerMember(String email, String password) {
+    final normalizedEmail = email.trim();
+    final existing = findMemberByEmail(normalizedEmail);
+    if (existing != null) {
+      _currentId = existing.id;
+      return existing;
+    }
+
+    // 목 저장소에서도 새 회원에게 독립된 id를 발급해 이후 모든 항목의 회원 구분 기준으로 사용합니다.
+    final member = Member(id: _nextId(), email: normalizedEmail, password: password);
+    _members.add(member);
+    _currentId = member.id;
+    _seedDefaultSettings(member.id);
+    return member;
+  }
+
+  int idForEmail(String email) {
+    final member = findMemberByEmail(email);
+    if (member == null) return _currentId;
+    return member.id;
+  }
+
+  List<Category> categoriesById(int id) => _categories.where((category) => category.id == id).toList(growable: false);
+
+  List<PaymentMethod> paymentMethodsById(int id) =>
+      _paymentMethods.where((method) => method.id == id).toList(growable: false);
+
+  List<ScheduleWithTasks> schedulesByDate(DateTime date, {int? id}) {
+    final targetId = id ?? currentMember.id;
     return _schedules
-        .where((schedule) => schedule.memberId == targetMemberId && _isSameDate(schedule.startTime, date))
+        .where((schedule) => schedule.id == targetId && _isSameDate(schedule.startTime, date))
         .map((schedule) {
-          final tasks = _tasks.where((task) => task.scheduleId == schedule.id).toList(growable: false);
+          // 할 일은 일정 번호뿐 아니라 회원 고유번호(id)도 확인해 다른 회원의 항목이 섞이지 않게 합니다.
+          final tasks = _tasks
+              .where((task) => task.id == targetId && task.scheduleId == schedule.scheduleId)
+              .toList(growable: false);
           return ScheduleWithTasks(schedule: schedule, tasks: tasks);
         })
         .toList(growable: false);
   }
 
-  List<Task> tasksByDate(DateTime date, {int? memberId}) => schedulesByDate(date, memberId: memberId)
+  List<Task> tasksByDate(DateTime date, {int? id}) => schedulesByDate(date, id: id)
       .expand((scheduleWithTasks) => scheduleWithTasks.tasks)
       .toList(growable: false);
 
-  List<AccountRecordView> accountRecordsByDate(DateTime date, {int? memberId}) {
-    final targetMemberId = memberId ?? currentMember.id;
+  List<AccountRecordView> accountRecordsByDate(DateTime date, {int? id}) {
+    final targetId = id ?? currentMember.id;
     return _accountRecords
-        .where((record) => record.memberId == targetMemberId && _isSameDate(record.transactionTime, date))
+        .where((record) => record.id == targetId && _isSameDate(record.transactionTime, date))
         .map(_toAccountRecordView)
         .toList(growable: false);
   }
 
-  List<AccountRecordView> allAccountRecordViews({int? memberId}) {
-    final targetMemberId = memberId ?? currentMember.id;
+  List<AccountRecordView> allAccountRecordViews({int? id}) {
+    final targetId = id ?? currentMember.id;
     return _accountRecords
-        .where((record) => record.memberId == targetMemberId)
+        .where((record) => record.id == targetId)
         .map(_toAccountRecordView)
         .toList(growable: false);
   }
 
   /// 소비 상세/전체보기에서 최근 거래 순서로 사용할 수입·지출 조인 목록입니다.
-  List<AccountRecordView> sortedAccountRecordViews({int? memberId}) {
-    final records = allAccountRecordViews(memberId: memberId);
+  List<AccountRecordView> sortedAccountRecordViews({int? id}) {
+    final records = allAccountRecordViews(id: id);
     records.sort((left, right) => right.record.transactionTime.compareTo(left.record.transactionTime));
     return records;
   }
 
   /// ERD Category.type 값으로 수입/지출을 구분해 월별 거래를 필터링합니다.
-  List<AccountRecordView> accountRecordsByMonth(DateTime month, {String? type, int? memberId}) {
-    return sortedAccountRecordViews(memberId: memberId)
+  List<AccountRecordView> accountRecordsByMonth(DateTime month, {String? type, int? id}) {
+    return sortedAccountRecordViews(id: id)
         .where((view) =>
             view.record.transactionTime.year == month.year &&
             view.record.transactionTime.month == month.month &&
@@ -294,30 +390,61 @@ class MockErdRepository {
   }
 
   /// 상단 요약 카드에서 사용하는 오늘 수입/지출 합계를 계산합니다.
-  int todayTotalByType(String type, {int? memberId}) {
+  int todayTotalByType(String type, {int? id}) {
     final now = DateTime.now();
     final today = DateTime(now.year, now.month, now.day);
-    return accountRecordsByDate(today, memberId: memberId)
+    return accountRecordsByDate(today, id: id)
         .where((view) => view.category.type == type)
         .fold(0, (sum, view) => sum + view.record.amount.abs());
   }
 
   /// 카테고리별 지출 막대 차트에 사용할 월간 지출 합계를 계산합니다.
-  Map<Category, int> monthlyExpenseTotalsByCategory(DateTime month, {int? memberId}) {
+  Map<Category, int> monthlyExpenseTotalsByCategory(DateTime month, {int? id}) {
     final totals = <Category, int>{};
-    for (final view in accountRecordsByMonth(month, type: 'EXPENSE', memberId: memberId)) {
+    for (final view in accountRecordsByMonth(month, type: 'EXPENSE', id: id)) {
       totals.update(view.category, (value) => value + view.record.amount.abs(), ifAbsent: () => view.record.amount.abs());
     }
     return totals;
   }
 
   AccountRecordView _toAccountRecordView(AccountRecord record) {
-    final category = _categories.firstWhere((category) => category.id == record.categoryId);
-    final paymentMethod = _paymentMethods.firstWhere((method) => method.id == record.paymentMethodId);
+    // 조인 시에도 회원 고유번호(id)를 함께 검증해 다른 회원의 항목이 연결되지 않게 합니다.
+    final category = _categories.firstWhere(
+      (category) => category.categoryId == record.categoryId && category.id == record.id,
+    );
+    final paymentMethod = _paymentMethods.firstWhere(
+      (method) => method.paymentMethodId == record.paymentMethodId && method.id == record.id,
+    );
     final schedule = record.scheduleId == null
         ? null
-        : _schedules.firstWhere((schedule) => schedule.id == record.scheduleId);
+        : _schedules.firstWhere(
+            (schedule) => schedule.scheduleId == record.scheduleId && schedule.id == record.id,
+          );
     return AccountRecordView(record: record, category: category, paymentMethod: paymentMethod, schedule: schedule);
+  }
+
+  int _nextId() => _members.map((member) => member.id).reduce((left, right) => left > right ? left : right) + 1;
+
+  int _nextPaymentMethodId() =>
+      _paymentMethods.map((method) => method.paymentMethodId).reduce((left, right) => left > right ? left : right) + 1;
+
+  int _nextCategoryId() =>
+      _categories.map((category) => category.categoryId).reduce((left, right) => left > right ? left : right) + 1;
+
+  void _seedDefaultSettings(int id) {
+    // 신규 회원은 공용 데이터가 아니라 해당 회원 고유번호(id)를 가진 기본 설정만 별도로 받습니다.
+    var nextCategoryId = _nextCategoryId();
+    _categories.addAll([
+      Category(id: id, categoryId: nextCategoryId++, name: '이달 총 수입', type: 'INCOME'),
+      Category(id: id, categoryId: nextCategoryId++, name: '식비', type: 'EXPENSE'),
+      Category(id: id, categoryId: nextCategoryId, name: '교통비', type: 'EXPENSE'),
+    ]);
+
+    var nextPaymentMethodId = _nextPaymentMethodId();
+    _paymentMethods.addAll([
+      PaymentMethod(id: id, paymentMethodId: nextPaymentMethodId++, name: '기본카드'),
+      PaymentMethod(id: id, paymentMethodId: nextPaymentMethodId, name: '현금'),
+    ]);
   }
 
   bool _isSameDate(DateTime left, DateTime right) =>

--- a/lib/screen/auth/login_screen.dart
+++ b/lib/screen/auth/login_screen.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 
+import '../../data/mock_erd_repository.dart';
 import '../../routes/routes.dart';
 
 class LoginScreen extends StatefulWidget {
@@ -76,10 +77,20 @@ class _LoginScreenState extends State<LoginScreen> {
                     elevation: 0,
                   ),
                   onPressed: () {
+                    final loginEmail = _emailController.text.trim();
+                    // ✅ 로그인은 아이디(이메일)와 비밀번호가 모두 맞을 때만 회원 고유번호(id)를 확정합니다.
+                    final member = MockErdRepository.instance.login(loginEmail, _passwordController.text);
+                    if (member == null) {
+                      ScaffoldMessenger.of(context).showSnackBar(
+                        const SnackBar(content: Text('아이디 또는 비밀번호가 올바르지 않습니다.')),
+                      );
+                      return;
+                    }
+
                     // ✅ 로그인 시 입력한 email을 Main/MyPage로 전달합니다.
                     Navigator.of(context).pushReplacementNamed(
                       Routes.main,
-                      arguments: {'loginEmail': _emailController.text.trim()},
+                      arguments: {'loginEmail': loginEmail},
                     );
                   },
                   child: const Text(

--- a/lib/screen/auth/sighup_screen.dart
+++ b/lib/screen/auth/sighup_screen.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 
+import '../../data/mock_erd_repository.dart';
 import '../../routes/routes.dart';
 
 class SignupScreen extends StatefulWidget {
@@ -34,6 +35,9 @@ class _SignupScreenState extends State<SignupScreen> {
       );
       return;
     }
+
+    // ✅ 가입한 회원도 즉시 고유 id를 발급해 이후 항목이 회원별로 분리되도록 합니다.
+    MockErdRepository.instance.registerMember(_emailController.text.trim(), password);
 
     ScaffoldMessenger.of(context).showSnackBar(
       const SnackBar(content: Text('회원가입이 완료되었습니다. 로그인해 주세요.')),

--- a/lib/screen/cash/cash_detail__screen.dart
+++ b/lib/screen/cash/cash_detail__screen.dart
@@ -21,10 +21,12 @@ class CashDetailScreen extends StatelessWidget {
   Widget build(BuildContext context) {
     final repository = MockErdRepository.instance;
     final now = DateTime.now();
-    final recentRecords = repository.sortedAccountRecordViews().take(4).toList(growable: false);
-    final expenseTotals = repository.monthlyExpenseTotalsByCategory(now);
-    final todayIncome = repository.todayTotalByType('INCOME');
-    final todayExpense = repository.todayTotalByType('EXPENSE');
+    // ✅ 로그인 회원 고유번호(id)를 모든 현금/소비 요약 조회에 전달합니다.
+    final id = repository.idForEmail(loginEmail);
+    final recentRecords = repository.sortedAccountRecordViews(id: id).take(4).toList(growable: false);
+    final expenseTotals = repository.monthlyExpenseTotalsByCategory(now, id: id);
+    final todayIncome = repository.todayTotalByType('INCOME', id: id);
+    final todayExpense = repository.todayTotalByType('EXPENSE', id: id);
 
     return Scaffold(
       backgroundColor: Colors.white,

--- a/lib/screen/cash/cash_records_screen.dart
+++ b/lib/screen/cash/cash_records_screen.dart
@@ -32,7 +32,9 @@ class _CashRecordsScreenState extends State<CashRecordsScreen> {
 
   @override
   Widget build(BuildContext context) {
-    final records = _repository.accountRecordsByMonth(_visibleMonth, type: _filter.type);
+    // ✅ 현재 화면의 로그인 이메일에서 회원 고유번호(id)를 확인해 전체보기 거래도 회원별로 분리합니다.
+    final id = _repository.idForEmail(widget.loginEmail);
+    final records = _repository.accountRecordsByMonth(_visibleMonth, type: _filter.type, id: id);
     final grouped = _groupRecordsByCategory(records);
 
     return Scaffold(

--- a/lib/screen/day/day_detail__screen.dart
+++ b/lib/screen/day/day_detail__screen.dart
@@ -13,7 +13,10 @@ class DayDetailScreen extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final date = DateUtils.dateOnly(selectedDate ?? DateTime.now());
-    final schedules = MockErdRepository.instance.schedulesByDate(date);
+    final repository = MockErdRepository.instance;
+    // ✅ 상세 일정 목록도 로그인 회원 고유번호(id)로 필터링합니다.
+    final id = repository.idForEmail(loginEmail);
+    final schedules = repository.schedulesByDate(date, id: id);
 
     return BaseScaffold(
       title: 'Day Detail',

--- a/lib/screen/day/my_expense_category_screen.dart
+++ b/lib/screen/day/my_expense_category_screen.dart
@@ -12,9 +12,10 @@ class MyExpenseCategoryScreen extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final repository = MockErdRepository.instance;
-    final memberId = repository.currentMember.id;
-    final categories = repository.categories;
-    final paymentMethods = repository.paymentMethodsByMember(memberId);
+    // ✅ 설정 화면의 지출 수단/카테고리도 로그인 회원 id 기준으로만 표시합니다.
+    final id = repository.idForEmail(loginEmail);
+    final categories = repository.categoriesById(id);
+    final paymentMethods = repository.paymentMethodsById(id);
 
     return BaseScaffold(
       title: '지출 수단 및 카테고리',
@@ -30,7 +31,7 @@ class MyExpenseCategoryScreen extends StatelessWidget {
                 const SizedBox(height: 20),
                 const _SectionTitle(title: '지불수단'),
                 // ✅ ERD의 PaymentMethod 데이터를 목데이터로 표시하며, 백엔드 연동 시 실제 CRUD 응답으로 대체됩니다.
-                ...paymentMethods.map((method) => _SettingRow(title: method.name, subtitle: 'memberId: ${method.memberId}')),
+                ...paymentMethods.map((method) => _SettingRow(title: method.name, subtitle: 'id: ${method.id}')),
               ],
             ),
           ),

--- a/lib/screen/main_screen.dart
+++ b/lib/screen/main_screen.dart
@@ -159,9 +159,11 @@ class _MainScreenState extends State<MainScreen> {
   }
 
   List<Widget> _buildTabContent() {
-    final schedules = _repository.schedulesByDate(_selectedDate);
-    final tasks = _repository.tasksByDate(_selectedDate);
-    final records = _repository.accountRecordsByDate(_selectedDate);
+    // ✅ 로그인 이메일로 회원 고유번호(id)를 찾아 일정/할 일/소비 항목을 모두 회원별로 조회합니다.
+    final id = _repository.idForEmail(widget.loginEmail);
+    final schedules = _repository.schedulesByDate(_selectedDate, id: id);
+    final tasks = _repository.tasksByDate(_selectedDate, id: id);
+    final records = _repository.accountRecordsByDate(_selectedDate, id: id);
 
     switch (_selectedTab) {
       case _MainTab.schedule:
@@ -260,7 +262,7 @@ class _ScheduleCard extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final timeRange = '${_formatTime(item.schedule.startTime)} - ${_formatTime(item.schedule.endTime)}';
-    final color = item.schedule.id.isOdd ? _MainScreenState._primaryPink : const Color(0xFF1F1F1F);
+    final color = item.schedule.scheduleId.isOdd ? _MainScreenState._primaryPink : const Color(0xFF1F1F1F);
     final textColor = color.computeLuminance() < 0.5 ? Colors.white : Colors.black87;
     return Container(
       margin: const EdgeInsets.only(bottom: 8),


### PR DESCRIPTION
### Motivation
- 사용자 피드백에 따라 회원 구분 기준을 `id`(회원 고유번호)로 명확히 하고 `memberId` 이중 표기를 제거해 회원별 데이터가 섞이는 문제를 해결하려고 변경했습니다.
- 로그인은 아이디(이메일) + 비밀번호로 인증하고, 인증된 경우에만 저장소의 현재 회원 `id`를 확정하도록 동작을 보강하려는 의도입니다.

### Description
- 목 데이터 모델을 정리해 `PaymentMethod`, `Category`, `Schedule`, `Task`, `AccountRecord`에서 기존 `memberId` 필드를 제거하고 항목별 고유번호를 `paymentMethodId`, `categoryId`, `scheduleId`, `taskId`, `accountRecordId`로 분리했으며 회원 구분은 `id`로 일관되게 사용합니다 (`lib/data/mock_erd_repository.dart`).
- 저장소 API들을 `idForEmail`, `categoriesById`, `paymentMethodsById`, `{int? id}` 파라미터 형태로 변경하고 내부 조회/조인 로직에서 회원 고유번호 `id`로 필터링/검증하도록 수정했습니다 (`lib/data/mock_erd_repository.dart`).
- 로그인 로직을 이메일·비밀번호 검증으로 변경해 인증 실패 시 null 반환 및 화면에서 실패 안내를 표시하도록 수정했으며, 회원가입 시 신규 `id` 발급 후 기본 설정을 해당 `id`로 시드합니다 (`lib/data/mock_erd_repository.dart`, `lib/screen/auth/login_screen.dart`, `lib/screen/auth/sighup_screen.dart`).
- 홈/소비 상세/전체 거래/일정 상세/설정(지출 수단/카테고리) 등 화면에서 `idForEmail`로 얻은 회원 고유번호를 저장소 조회 파라미터로 전달하도록 연결 로직을 수정했습니다 (`lib/screen/main_screen.dart`, `lib/screen/cash/cash_detail__screen.dart`, `lib/screen/cash/cash_records_screen.dart`, `lib/screen/day/day_detail__screen.dart`, `lib/screen/day/my_expense_category_screen.dart`).

### Testing
- `git diff --check`를 실행해 공백/충돌 점검을 통과했습니다.
- `python3` 기반의 정적 검사 스크립트로 `memberId` 제거, `idForEmail`/`categoriesById`/`paymentMethodsById` 사용, 로그인 비밀번호 검증 로직 존재 등을 확인했고 통과했습니다.
- `flutter analyze`는 이 환경에 `flutter`가 없어 실행하지 못해 경고로 기록했습니다.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a02f51ac49c832792f0c64c26e3fc8b)